### PR TITLE
Progress bar during downloading of followers or followings

### DIFF
--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -2161,7 +2161,7 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
             print(f"* Error: {e}")
 
     if ((followers_count != followers_old_count) or (followers_count > 0 and not followers)) and not skip_session and not skip_followers and can_view:
-        print("\n* Getting followers ...")
+        # print("\n* Getting followers ...")
         followers_followings_fetched = True
 
         try:
@@ -2253,7 +2253,7 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
             print(f"* Error: {e}")
 
     if ((followings_count != followings_old_count) or (followings_count > 0 and not followings)) and not skip_session and not skip_followings and can_view:
-        print("\n* Getting followings ...")
+        # print("\n* Getting followings ...")
         followers_followings_fetched = True
 
         try:

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -14,6 +14,7 @@ python-dateutil
 pytz
 tzlocal (optional)
 python-dotenv (optional)
+tqdm
 """
 
 VERSION = "2.0"
@@ -1659,13 +1660,9 @@ def get_random_mobile_user_agent() -> str:
 
     return (f"Instagram {app_major}.{app_minor}.{app_patch}.{app_revision} ({device}{model}; iOS {os_major}_{os_minor}; {language}; {locale}; scale={scale:.2f}; {width}x{height}; {device_id}) AppleWebKit/420+")
 
-def extract_usernames_safely(data_dict):
-    """
-    Extracts usernames from a JSON response, automatically detecting if the
-    data is for 'following' ('edge_follow') or 'followers' ('edge_followed_by').
 
-    Returns a list of usernames or an empty list if the expected format is not found.
-    """
+# Extracts usernames from a JSON response, automatically detecting if the data is for 'following' or 'followers'
+def extract_usernames_safely(data_dict):
     usernames = []
 
     # Define the keys to look for in order of preference

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dateutil
 pytz
 tzlocal
 python-dotenv
+tqdm


### PR DESCRIPTION
Progress bar during downloading of followers or followings, to provide additional information, since this can take awhile. If someone is having challenges keeping their instagram login from not getting flagged, this is helpful because it shows what is going on.

_extract_usernames_safely_ is more elaborate than needed. It could just return a # of names, but I am also using this routine to log write the names to a log, so I didn't remove passing back the names.

Example while in progress:
```
Timestamp:              Thu 01 Jan 2026, 11:45:03
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────
* Followers (188) loaded from file 'instagram_xxx.json' (01 Jan 26, 11:08)

* Followings (4269) loaded from file 'instagram_xxx.json' (31 Dec 25, 20:17)
* Followings number changed by user xxx from 4269 to 4281 (+12)
* Downloading Followings:  31%|██████████████▎                               | 1336/4281 [11 names/req, reqs=116, mins=11.2, remain=25.1]
```

Example after initial loading of script:
```
* Followers (187) loaded from file 'instagram_XXX_followers.json' (31 Dec 25, 09:36)
* Followers number changed for user XXX from 187 to 188 (+1)
* Downloading Followers: 100%|█████████████████████████████████████████████████████| 188/188 [9 names/req, reqs=19, mins=1.7, remain=0.0]
* Followers saved to file 'instagram_XXX_followers.json'

* Followings (4266) loaded from file 'instagram_XXX_followings.json' (31 Dec 25, 09:36)
* Followings number changed by user XXX from 4266 to 4267 (+1)
* Downloading Following: 100%|███████████████████████████████████████████████▉| 4266/4267 [11 names/req, reqs=378, mins=34.4, remain=0.0]
* Followings saved to file 'instagram_XXX_followings.json'
```

The only oddity is if an instaloader error occurs, which can cause the following. It's not a big deal, but I'd prefer to be able to filter those out.
```
* Downloading Followings:  16%|████████                                         | 699/4281 [11 names/req, reqs=60, mins=5.8, remain=31.0]JSON Query to graphql/query: HTTPSConnectionPool(host='www.instagram.com', port=443): Max retries exceeded with url: /graphql/query?query_hash=58712303d941c6855d4e888c5f0cd22f&variables=%7B%22id%22%3A%2227129100349%22%2C%22first%22%3A12%2C%22after%22%3A%22QVFEV05KNHNpT25XSEpfcnQ2Sk9hQ3huM28tWGcyUXU1OFh1c0RMRjFnVVcwajNZTGY3Z3NRRHBKampPdl9vaTlhN1YzQ3l4YjhPZlN1RXFLM3VuLTd6TQ%3D%3D%22%7D (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x000001BD178B2B60>: Failed to resolve 'www.instagram.com' ([Errno 11001] getaddrinfo failed)")) [retrying; skip with ^C]
* Downloading Followings:  28%|█████████████                                  | 1187/4281 [11 names/req, reqs=103, mins=9.7, remain=23.7]
```