### PR TITLE
Add clarity when # of followers or followings changes as to what the …

### DIFF
--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -464,16 +464,11 @@ def session_label() -> str:
     # Session is shared across targets, include it in error notifications for clarity
     return SESSION_USERNAME if SESSION_USERNAME else "<anonymous>"
 
-def get_follower_count(profile):
-    tempcnt = profile.get_followers().count
-    return tempcnt
-    
-def get_following_count(profile):
-    tempcnt = profile.get_followees().count
-    return tempcnt
 
-def show_follow_info(followers1, followers2, followers_actual, followees1, followees2, followees_actual):
-    print(f"* Followings ({followees1}) actual ({followees_actual}). Followers ({followers1}) actual ({followers_actual})")
+# Displays comparison between reported and actual follower/following counts
+def show_follow_info(followers_reported: int, followers_actual: int, followings_reported: int, followings_actual: int) -> None:
+    print(f"* Followers: reported ({followers_reported}) actual ({followers_actual}). Followings: reported ({followings_reported}) actual ({followings_actual})")
+
 
 # Logger class to output messages to stdout and log file
 class Logger(object):
@@ -2740,9 +2735,8 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
                         followings = []
                         followings = [followee.username for followee in profile.get_followees()]
                         followings_to_save = []
-                        profile = instaloader.Profile.from_username(bot.context, user)
-                        show_follow_info(profile.followers, get_follower_count(profile), len(followers), profile.followees, get_following_count(profile), len(followings))
                         followings_count = profile.followees
+                        show_follow_info(followers_count, len(followers), followings_count, len(followings))
                         if not followings and followings_count > 0:
                             print("* Empty followings list returned, not saved to file")
                         else:
@@ -2839,9 +2833,8 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
                         followers = []
                         followers = [follower.username for follower in profile.get_followers()]
                         followers_to_save = []
-                        profile = instaloader.Profile.from_username(bot.context, user)
-                        show_follow_info(profile.followers, get_follower_count(profile), len(followers), profile.followees, get_following_count(profile), len(followings))
                         followers_count = profile.followers
+                        show_follow_info(followers_count, len(followers), followings_count, len(followings))
                         if not followers and followers_count > 0:
                             print("* Empty followers list returned, not saved to file")
                         else:

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -464,6 +464,16 @@ def session_label() -> str:
     # Session is shared across targets, include it in error notifications for clarity
     return SESSION_USERNAME if SESSION_USERNAME else "<anonymous>"
 
+def get_follower_count(profile):
+    tempcnt = profile.get_followers().count
+    return tempcnt
+    
+def get_following_count(profile):
+    tempcnt = profile.get_followees().count
+    return tempcnt
+
+def show_follow_info(followers1, followers2, followers_actual, followees1, followees2, followees_actual):
+    print(f"*** Followings ({followees1}) actual ({followees_actual}) *** Followers ({followers1}) actual ({followers_actual})")
 
 # Logger class to output messages to stdout and log file
 class Logger(object):
@@ -2189,7 +2199,7 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
             if followers_count == followers_old_count:
                 followers = followers_old
             followers_mdate = datetime.fromtimestamp(int(os.path.getmtime(insta_followers_file)), pytz.timezone(LOCAL_TIMEZONE))
-            print(f"* Followers ({followers_old_count}) loaded from file '{insta_followers_file}' ({get_short_date_from_ts(followers_mdate, show_weekday=False, always_show_year=True)})")
+            print(f"* Followers ({followers_old_count}) actual ({len(followers_old)}) loaded from file '{insta_followers_file}' ({get_short_date_from_ts(followers_mdate, show_weekday=False, always_show_year=True)})")
             followers_followings_fetched = True
 
     if followers_count != followers_old_count:
@@ -2231,7 +2241,7 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
             try:
                 with open(insta_followers_file, 'w', encoding="utf-8") as f:
                     json.dump(followers_to_save, f, indent=2)
-                    print(f"* Followers saved to file '{insta_followers_file}'")
+                    print(f"* Followers ({followers_count}) actual ({len(followers)}) saved to file '{insta_followers_file}'")
             except Exception as e:
                 print(f"* Cannot save list of followers to '{insta_followers_file}' file: {e}")
 
@@ -2280,7 +2290,7 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
             if followings_count == followings_old_count:
                 followings = followings_old
             following_mdate = datetime.fromtimestamp(int(os.path.getmtime(insta_followings_file)), pytz.timezone(LOCAL_TIMEZONE))
-            print(f"\n* Followings ({followings_old_count}) loaded from file '{insta_followings_file}' ({get_short_date_from_ts(following_mdate, show_weekday=False, always_show_year=True)})")
+            print(f"\n* Followings ({followings_old_count}) actual ({len(followings_old)}) loaded from file '{insta_followings_file}' ({get_short_date_from_ts(following_mdate, show_weekday=False, always_show_year=True)})")
             followers_followings_fetched = True
 
     if followings_count != followings_old_count:
@@ -2321,7 +2331,7 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
             try:
                 with open(insta_followings_file, 'w', encoding="utf-8") as f:
                     json.dump(followings_to_save, f, indent=2)
-                    print(f"* Followings saved to file '{insta_followings_file}'")
+                    print(f"* Followings ({followings_count}) actual ({len(followings)}) saved to file '{insta_followings_file}'")
             except Exception as e:
                 print(f"* Cannot save list of followings to '{insta_followings_file}' file: {e}")
 
@@ -2730,6 +2740,8 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
                         followings = []
                         followings = [followee.username for followee in profile.get_followees()]
                         followings_to_save = []
+                        profile = instaloader.Profile.from_username(bot.context, user)
+                        show_follow_info(profile.followers, get_follower_count(profile), len(followers), profile.followees, get_following_count(profile), len(followings))
                         followings_count = profile.followees
                         if not followings and followings_count > 0:
                             print("* Empty followings list returned, not saved to file")
@@ -2826,6 +2838,8 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
                         followers = []
                         followers = [follower.username for follower in profile.get_followers()]
                         followers_to_save = []
+                        profile = instaloader.Profile.from_username(bot.context, user)
+                        show_follow_info(profile.followers, get_follower_count(profile), len(followers), profile.followees, get_following_count(profile), len(followings))
                         followers_count = profile.followers
                         if not followers and followers_count > 0:
                             print("* Empty followers list returned, not saved to file")

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -473,7 +473,7 @@ def get_following_count(profile):
     return tempcnt
 
 def show_follow_info(followers1, followers2, followers_actual, followees1, followees2, followees_actual):
-    print(f"*** Followings ({followees1}) actual ({followees_actual}) *** Followers ({followers1}) actual ({followers_actual})")
+    print(f"* Followings ({followees1}) actual ({followees_actual}). Followers ({followers1}) actual ({followers_actual})")
 
 # Logger class to output messages to stdout and log file
 class Logger(object):
@@ -2750,6 +2750,7 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
                             followings_to_save.append(followings)
                             with open(insta_followings_file, 'w', encoding="utf-8") as f:
                                 json.dump(followings_to_save, f, indent=2)
+                                print(f"* Followings ({followings_count}) actual ({len(followings)}) saved to file '{insta_followings_file}'")
                     except Exception as e:
                         followings = followings_old
                         print(f"* Error while processing followings: {type(e).__name__}: {e}")
@@ -2848,6 +2849,7 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
                             followers_to_save.append(followers)
                             with open(insta_followers_file, 'w', encoding="utf-8") as f:
                                 json.dump(followers_to_save, f, indent=2)
+                                print(f"* Followers ({followers_count}) actual ({len(followers)}) saved to file '{insta_followers_file}'")
                     except Exception as e:
                         followers = followers_old
                         print(f"* Error while processing followers: {type(e).__name__}: {e}")


### PR DESCRIPTION
During script initialization, show info around loading the two profiles. It's useful to show what is happening during just a long blank time when coming up. This details is also useful for people are seeing issues with keeping an account from being banned; any detail helps narrow things down.

In the runtime example, you can see that I have added two ways to show the data. It's your choice, or something else.
At Startup:
```
* Followers (188) actual (188) loaded from file 'instagram_XXX_followers.json' (01 Jan 26, 11:08)

* Followings (4269) actual (4269) loaded from file 'instagram_XXX_followings.json' (31 Dec 25, 20:17)
* Followings number changed by user XXX from 4269 to 4281 (+12)

* Getting followings ...
* Followings (4281) actual (4280) saved to file 'instagram_XXX_followings.json'
```

Runtime:
```
*** Fetching Updates. Current Hour: 10. Allowed hours: [9, 10, 21, 22]
* Followings number changed by user XXX from 4211 to 4212 (+1)
* Followings (4212) actual (4213). Followers (189) actual (189)
* Followings (4212) actual (4213) saved to file 'instagram_XXX_followings.json'
```

