### PR TITLE
Multiple pbar fixes

### DIFF
--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -5883,7 +5883,7 @@ def instagram_wrap_request(orig_request):
                 # Calculate Remaining Minutes
                 d = thread_pbar.format_dict
                 rate = d['rate'] if d['rate'] else 0
-                remaining_items = d['total'] - d['n']
+                remaining_items = d['total'] - (d['n'] + increment)
 
                 # Calculate remaining seconds, then minutes
                 rem_s = remaining_items / rate if rate > 0 else 0

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -5892,7 +5892,7 @@ def instagram_wrap_request(orig_request):
                 elapsed_m = d['elapsed'] / 60
 
                 # Update Stats - use float division for precision
-                names_per_req = d['n'] / thread_wrapper_count if thread_wrapper_count > 0 else 0
+                names_per_req = (d['n'] + increment) / thread_wrapper_count if thread_wrapper_count > 0 else 0
                 stats_string = f"{names_per_req:.1f} names/req, reqs={thread_wrapper_count:d}, mins={elapsed_m:.1f}, remain={rem_m:.1f}"
                 thread_pbar.unit = stats_string
                 thread_pbar.update(increment)

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -5649,7 +5649,10 @@ def close_pbar():
     global pbar
     # Use thread-local storage for multi-target safety
     thread_pbar = getattr(_thread_local, 'pbar', None)
-    debug_print(f"[close_pbar] ENTRY - thread_pbar is None: {thread_pbar is None}")
+    if thread_pbar:
+        tqdm.write(f"\n[close_pbar] ENTRY - thread_pbar is None: {thread_pbar is None}")
+    else:
+        debug_print(f"\n[close_pbar] ENTRY - thread_pbar is None: {thread_pbar is None}")
     try:
         if thread_pbar is not None:
             final_str = None

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -974,8 +974,6 @@ _thread_local = threading.local()
 
 # Helper function to run Flask app with suppressed startup messages
 def run_flask_quietly(app, host, port, debug=False, use_reloader=False, threaded=True):
-    import sys
-
     # Filter class that suppresses Flask startup messages but allows errors through
     class FilteredWriter:
         def __init__(self, original_stream):
@@ -2868,7 +2866,8 @@ class Logger(object):
                 LAST_OUTPUT_BY_THREAD[tid].append(message)
 
             if not (DASHBOARD_ENABLED and RICH_AVAILABLE):
-                if not pbar:
+                # Suppress terminal writes only for the thread that currently owns a progress bar
+                if getattr(_thread_local, 'pbar', None) is None:
                     self.terminal.write(colorized_message)
                     self.terminal.flush()
 
@@ -4688,7 +4687,6 @@ def dashboard_input_handler():
     # This toggles the dashboard mode for both the Terminal Dashboard and the Web-based dashboard
     global MANUAL_CHECK_TRIGGERED, DASHBOARD_MODE
 
-    import sys
     is_windows = platform.system() == "Windows"
 
     if is_windows:
@@ -5607,12 +5605,11 @@ def setup_pbar(total_expected, title):
             def __getattr__(self, name):
                 return getattr(self._stream, name)
 
-        import shutil, sys
-
         def _get_actual_console_width(fallback=80):
             try:
                 if sys.platform == 'win32':
-                    import ctypes, struct
+                    import ctypes
+                    import struct
                     handle = ctypes.windll.kernel32.GetStdHandle(-11)
                     csbi = ctypes.create_string_buffer(22)
                     if ctypes.windll.kernel32.GetConsoleScreenBufferInfo(handle, csbi):
@@ -5626,7 +5623,7 @@ def setup_pbar(total_expected, title):
             return shutil.get_terminal_size(fallback=(fallback, 24)).columns
 
         actual_width = _get_actual_console_width()
-        safe_ncols = min(HORIZONTAL_LINE, actual_width - 1)
+        safe_ncols = max(20, min(HORIZONTAL_LINE, actual_width - 1))
         # print(f"DEBUG: terminal width is {safe_ncols}")
 
         custom_bar_format = "{l_bar}{bar}| {n_fmt}/{total_fmt} [{unit}]"
@@ -5649,10 +5646,7 @@ def close_pbar():
     global pbar
     # Use thread-local storage for multi-target safety
     thread_pbar = getattr(_thread_local, 'pbar', None)
-    if thread_pbar:
-        tqdm.write(f"\n[close_pbar] ENTRY - thread_pbar is None: {thread_pbar is None}")
-    else:
-        debug_print(f"\n[close_pbar] ENTRY - thread_pbar is None: {thread_pbar is None}")
+    debug_print(f"[close_pbar] ENTRY - thread_pbar is None: {thread_pbar is None}")
     try:
         if thread_pbar is not None:
             final_str = None
@@ -5894,10 +5888,10 @@ def instagram_wrap_request(orig_request):
                 # Update Stats - use float division for precision
                 names_per_req = (d['n'] + increment) / thread_wrapper_count if thread_wrapper_count > 0 else 0
                 total_reqs = d['n'] + increment
-                if not rate and (total_reqs and names_per_req): # intended only for first iteration where rate = 0, or an error condition where rate is 0
+                if not rate and (total_reqs and names_per_req):  # intended only for first iteration where rate = 0, or an error condition where rate is 0
                     mins_per_req = elapsed_m / total_reqs
                     rem_m = remaining_items * mins_per_req
-                    
+
                 stats_string = f"{names_per_req:.1f} names/req, reqs={thread_wrapper_count:d}, mins={elapsed_m:.1f}, remain={rem_m:.1f}"
                 thread_pbar.unit = stats_string
                 thread_pbar.update(increment)

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -2868,8 +2868,9 @@ class Logger(object):
                 LAST_OUTPUT_BY_THREAD[tid].append(message)
 
             if not (DASHBOARD_ENABLED and RICH_AVAILABLE):
-                self.terminal.write(colorized_message)
-                self.terminal.flush()
+                if not pbar:
+                    self.terminal.write(colorized_message)
+                    self.terminal.flush()
 
             # Expand tabs for file output and ensure ANSI codes are stripped
             clean_message = ANSI_ESCAPE_RE.sub("", colorized_message).expandtabs(8)

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -5893,6 +5893,11 @@ def instagram_wrap_request(orig_request):
 
                 # Update Stats - use float division for precision
                 names_per_req = (d['n'] + increment) / thread_wrapper_count if thread_wrapper_count > 0 else 0
+                total_reqs = d['n'] + increment
+                if not rate and (total_reqs and names_per_req): # intended only for first iteration where rate = 0, or an error condition where rate is 0
+                    mins_per_req = elapsed_m / total_reqs
+                    rem_m = remaining_items * mins_per_req
+                    
                 stats_string = f"{names_per_req:.1f} names/req, reqs={thread_wrapper_count:d}, mins={elapsed_m:.1f}, remain={rem_m:.1f}"
                 thread_pbar.unit = stats_string
                 thread_pbar.update(increment)

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -5607,12 +5607,34 @@ def setup_pbar(total_expected, title):
             def __getattr__(self, name):
                 return getattr(self._stream, name)
 
+        import shutil, sys
+
+        def _get_actual_console_width(fallback=80):
+            try:
+                if sys.platform == 'win32':
+                    import ctypes, struct
+                    handle = ctypes.windll.kernel32.GetStdHandle(-11)
+                    csbi = ctypes.create_string_buffer(22)
+                    if ctypes.windll.kernel32.GetConsoleScreenBufferInfo(handle, csbi):
+                        left, top, right, bottom = struct.unpack_from('hhhh', csbi.raw, 10)
+                        width = right - left + 1
+                        if width > 0:
+                            return width
+            except Exception:
+                pass
+            # Non-Windows or fallback: shutil is reliable on Linux/Mac
+            return shutil.get_terminal_size(fallback=(fallback, 24)).columns
+
+        actual_width = _get_actual_console_width()
+        safe_ncols = min(HORIZONTAL_LINE, actual_width - 1)
+        # print(f"DEBUG: terminal width is {safe_ncols}")
+
         custom_bar_format = "{l_bar}{bar}| {n_fmt}/{total_fmt} [{unit}]"
         # Write progress bar updates to terminal only (not log file) to avoid cluttering logs
         terminal_out = stdout_bck if stdout_bck is not None else sys.stdout
         locked_terminal_out = _LockedStream(terminal_out, STDOUT_LOCK)
         # Use HORIZONTAL_LINE (default 113) as the fixed width for consistent behavior across environments
-        _thread_local.pbar = tqdm(total=total_expected, bar_format=custom_bar_format, unit="Initializing...", desc=title, file=locked_terminal_out, ncols=HORIZONTAL_LINE)  # type: ignore[misc]
+        _thread_local.pbar = tqdm(total=total_expected, bar_format=custom_bar_format, unit="Initializing...", desc=title, file=locked_terminal_out, ncols=safe_ncols)  # type: ignore[misc]
 
         # Also set global for backward compatibility (single-threaded mode)
         pbar = _thread_local.pbar


### PR DESCRIPTION
1. During pbar updates, send random prints only to log, not screen. I tested this in single account mode. The only downside is you could miss a message that would have occurred during the pbar update. However, it's really a corner case of clicking things in the web dashboard that was causing pbar screen update issues. Those messages are not critical. If you don't want to implement this, I understand.

2. Use current console width to set width of pbar. Screen width could be less than HORIZONTAL_LINE, which causes pbar to not be able to /r and update the same line. This specifically was noticed when using RDP to access Windows Terminal but the RDP was disconnected, causing screen width to go to 102. The code should be OS independent, but I tested on Windows.

`Downloading Followings: 0%| | 0/4454 [Initi* Downloading Followings: 0%| | 12/4454 [0.0 names/req, reqs=1, mins=0.2, * Downloading Followings: 1%|▏ | 24/4454 [6.0 names/req, reqs=2, mins=0.3, r* Downloading Followings: 1%|▏ | 36/4454 [8.0 names/req, reqs=3, mins=0.4, r* Downloading Followings: 1%|▎ | 48/4454 [9.0 names/req, reqs=4, mins=0.5, r* Downloading Followings: 1%|▎ | 60/4454 [9.6 names/req, reqs=5, mins=0.5, r* Downloading Followings: 2%|▍ | 72/4454 [10.0 names/req, reqs=6, mins=0.6, r* Downloading Followings: 2%|▍ | 84/4454 [10.3 names/req, reqs=7, mins=0.7, r* Downloading Followings: 2%|▌ | 96/4454 [10.5 names/req, reqs=8, mins=0.8, remain=34.0]`

3. Debug statement occurs before pbar is closed, so it needs to use tqdm.write
