### PR TITLE
Privacy Substitution Feature

### DIFF
--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -183,7 +183,7 @@ JITTER_VERBOSE = False
 
 # Optional Privacy Substitutions
 # This allows you to substitute any string for another in all messaging, logging, webhooks, and emails.
-# For instance, you may want to change a particular Instagram username to a more friendy name, or you could mask a name.
+# For instance, you may want to change a particular Instagram username to a more friendly name, or you could mask a name.
 # 
 # Provide a list of (search, replace) tuples. Any search term will be substituted with the replace term.
 #

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -181,6 +181,17 @@ ENABLE_JITTER = False
 # Set to True to enable verbose output for HTTP jitter/back-off wrappers
 JITTER_VERBOSE = False
 
+# Optional Privacy Substitutions
+# This allows you to substitute any string for another in all messaging, logging, and emailing.
+# For instance, you may want to change a particular Instagram username to a more friendy name, or you could mask a name.
+# 
+# Provide a list of (search, replace) tuples. Any search term will be substituted with the replace term.
+#
+# Example:
+# PRIVACY_SUBSTITIONS = [ ("a.username", "XXX"), ("sdfsdf747475475", "Bobby") ]
+#
+PRIVACY_SUBSTITIONS = [ ]
+
 # Optional: specify web browser user agent manually
 #
 # For session login using Firefox cookies, ensure this matches your Firefox web browser's user agent
@@ -664,6 +675,7 @@ DASHBOARD_SHOW_CHECK_SECONDS = True
 THUMBNAILS_FORCED_BY_WEB = False
 FOLLOWERS_CHURN_DETECTION = False
 TIME_FORMAT_12H = False
+PRIVACY_SUBSTITIONS = []
 mode_of_the_tool = "Unknown"
 
 exec(CONFIG_BLOCK, globals())
@@ -2865,6 +2877,7 @@ class Logger(object):
         global last_output
         with STDOUT_LOCK:
             # Apply color for terminal
+            message = process_message_substitutions(message)
             colorized_message = apply_color_to_text(message)
 
             if message != '\n':
@@ -3101,6 +3114,10 @@ def send_email(subject, body, body_html, use_ssl, image_file="", image_name="ima
     fqdn_re = re.compile(r'(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}\.?$)')
     email_re = re.compile(r'[^@]+@[^@]+\.[^@]+')
 
+    subject = process_message_substitutions(subject)
+    body = process_message_substitutions(body)
+    body_html = process_message_substitutions(body_html)
+
     try:
         ipaddress.ip_address(str(SMTP_HOST))
     except ValueError:
@@ -3333,6 +3350,9 @@ def send_webhook(title, description, color=0x7289DA, fields=None, image_url=None
     if not WEBHOOK_ENABLED or not WEBHOOK_URL:
         return 1
 
+    title = process_message_substitutions(title)
+    description = process_message_substitutions(description)
+
     # Validate webhook URL
     if not validate_webhook_url(WEBHOOK_URL):
         debug_print("* Webhook error: Invalid webhook URL format")
@@ -3453,12 +3473,31 @@ def send_webhook(title, description, color=0x7289DA, fields=None, image_url=None
     return 1
 
 
+def process_message_substitutions(message: str) -> str:
+    """
+    Perform search/replace on a message using the PRIVACY_SUBSTITIONS global variable.
+    PRIVACY_SUBSTITIONS should be a list of (search, replace) tuples.
+    Returns the original message if PRIVACY_SUBSTITIONS doesn't exist or is empty.
+    """
+    try:
+        if not PRIVACY_SUBSTITIONS:
+            return message
+    except NameError:
+        return message
+
+    for search, replace in PRIVACY_SUBSTITIONS:
+        message = message.replace(search, replace)
+
+    return message
+
+   
 # Debug print helper - only prints if DEBUG_MODE is enabled
 def debug_print(message):
     if DEBUG_MODE:
+        message = process_message_substitutions(message)
         timestamp = get_hour_min_from_ts(now_local(), show_seconds=True)
         user = getattr(_thread_local, 'user', None)
-        user_prefix = f" [{user}]" if user else ""
+        user_prefix = f" [{process_message_substitutions(user)}]" if user else ""
 
         # If we just printed a partial line (no newline), add one before the debug message to avoid clobbering
         if getattr(_thread_local, 'in_partial_line', False):

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -182,7 +182,7 @@ ENABLE_JITTER = False
 JITTER_VERBOSE = False
 
 # Optional Privacy Substitutions
-# This allows you to substitute any string for another in all messaging, logging, and emailing.
+# This allows you to substitute any string for another in all messaging, logging, webhooks, and emails.
 # For instance, you may want to change a particular Instagram username to a more friendy name, or you could mask a name.
 # 
 # Provide a list of (search, replace) tuples. Any search term will be substituted with the replace term.

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -3699,8 +3699,9 @@ def refresh_proxy_if_needed(bot, user):
 def apply_privacy_substitutions(content):
     """
     Apply PRIVACY_SUBSTITIONS to any content type.
-    - Recurses into dicts and lists
+    - Recurses into dict values and list items
     - For strings, performs search/replace using PRIVACY_SUBSTITIONS
+    - Preserves dictionary keys to keep API object identity stable
     - Non-string primitives are returned unchanged
     """
     if not PRIVACY_SUBSTITIONS:
@@ -3710,7 +3711,7 @@ def apply_privacy_substitutions(content):
             content = content.replace(search, replace)
         return content
     if isinstance(content, dict):
-        return {apply_privacy_substitutions(k): apply_privacy_substitutions(v) for k, v in content.items()}
+        return {k: apply_privacy_substitutions(v) for k, v in content.items()}
     if isinstance(content, list):
         return [apply_privacy_substitutions(item) for item in content]
     return content

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -1325,6 +1325,7 @@ def create_web_dashboard_app():
                 # Keep output best-effort; don't break dashboard on edge cases
                 pass
 
+            data = apply_privacy_substitutions(data)
             return jsonify(data)  # type: ignore
 
     # Catch TemplateNotFound specifically to show friendly error
@@ -1668,7 +1669,7 @@ def create_web_dashboard_app():
         global DASHBOARD_SHOW_CHECK_SECONDS, TIME_FORMAT_12H
 
         if flask_request.method == 'GET':  # type: ignore
-            return jsonify({  # type: ignore
+            data = {  # type: ignore
                 'check_interval': INSTA_CHECK_INTERVAL,
                 'random_low': RANDOM_SLEEP_DIFF_LOW,
                 'random_high': RANDOM_SLEEP_DIFF_HIGH,
@@ -1722,7 +1723,9 @@ def create_web_dashboard_app():
                 'min_h2': MIN_H2,
                 'max_h2': MAX_H2,
                 'dashboard_show_check_seconds': DASHBOARD_SHOW_CHECK_SECONDS,
-            })
+            }
+            data = apply_privacy_substitutions(data)
+            return jsonify(data)
         elif flask_request.method == 'POST':  # type: ignore
             data = flask_request.get_json(silent=True) or {}  # type: ignore
             ok, changes, err, code = apply_settings_update(data)
@@ -2464,6 +2467,7 @@ def update_ui_data(targets=None, config=None, check_count=None, last_check=None,
                             tgt_parts.append(f"session={s}")
                 parts.append(f"[{', '.join(tgt_parts)}]")
         if parts:
+            parts = apply_privacy_substitutions(parts)
             debug_print(f"UI Data Update: {', '.join(parts)}")
     if DASHBOARD_ENABLED or WEB_DASHBOARD_ENABLED:
         if DASHBOARD_ENABLED:
@@ -2540,6 +2544,7 @@ def log_activity(message, user=None, level='system', details=None, to_web=True):
 
     # Format message with user if provided
     display_message = f"[{user}] {message}" if user else message
+    display_message = apply_privacy_substitutions(display_message)
 
     activity_item_rich = {
         'time': timestamp_str,
@@ -2997,7 +3002,7 @@ class Logger(object):
         global last_output
         with STDOUT_LOCK:
             # Apply color for terminal
-            message = process_message_substitutions(message)
+            message = apply_privacy_substitutions(message)
             colorized_message = apply_color_to_text(message)
 
             if message != '\n':
@@ -3058,7 +3063,7 @@ class ColorStream(object):
         self.terminal = stream
 
     def write(self, message):
-        coloured = apply_color_to_text(message)
+        coloured = apply_color_to_text(apply_privacy_substitutions(message))
         self.terminal.write(coloured)
         self.terminal.flush()
 
@@ -3234,9 +3239,9 @@ def send_email(subject, body, body_html, use_ssl, image_file="", image_name="ima
     fqdn_re = re.compile(r'(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}\.?$)')
     email_re = re.compile(r'[^@]+@[^@]+\.[^@]+')
 
-    subject = process_message_substitutions(subject)
-    body = process_message_substitutions(body)
-    body_html = process_message_substitutions(body_html)
+    subject = apply_privacy_substitutions(subject)
+    body = apply_privacy_substitutions(body)
+    body_html = apply_privacy_substitutions(body_html)
 
     try:
         ipaddress.ip_address(str(SMTP_HOST))
@@ -3470,8 +3475,8 @@ def send_webhook(title, description, color=0x7289DA, fields=None, image_url=None
     if not WEBHOOK_ENABLED or not WEBHOOK_URL:
         return 1
 
-    title = process_message_substitutions(title)
-    description = process_message_substitutions(description)
+    title = apply_privacy_substitutions(title)
+    description = apply_privacy_substitutions(description)
 
     # Validate webhook URL
     if not validate_webhook_url(WEBHOOK_URL):
@@ -3691,34 +3696,39 @@ def refresh_proxy_if_needed(bot, user):
                 log_activity(f"Proxy refresh failed: {error_msg}", user=user, level='error')
 
 
-def process_message_substitutions(message: str) -> str:
+def apply_privacy_substitutions(content):
     """
-    Perform search/replace on a message using the PRIVACY_SUBSTITIONS global variable.
-    PRIVACY_SUBSTITIONS should be a list of (search, replace) tuples.
-    Returns the original message if PRIVACY_SUBSTITIONS doesn't exist or is empty.
+    Apply PRIVACY_SUBSTITIONS to any content type.
+    - Recurses into dicts and lists
+    - For strings, performs search/replace using PRIVACY_SUBSTITIONS
+    - Non-string primitives are returned unchanged
     """
-    if PRIVACY_SUBSTITIONS:
-        if not isinstance(message, str):
-            message = str(message)
+    if not PRIVACY_SUBSTITIONS:
+        return content
+    if isinstance(content, str):
         for search, replace in PRIVACY_SUBSTITIONS:
-            message = message.replace(search, replace)
-    return message
+            content = content.replace(search, replace)
+        return content
+    if isinstance(content, dict):
+        return {apply_privacy_substitutions(k): apply_privacy_substitutions(v) for k, v in content.items()}
+    if isinstance(content, list):
+        return [apply_privacy_substitutions(item) for item in content]
+    return content
+    
 
-   
 # Debug print helper - only prints if DEBUG_MODE is enabled
 def debug_print(message):
     if DEBUG_MODE:
-        message = process_message_substitutions(message)
         timestamp = get_hour_min_from_ts(now_local(), show_seconds=True)
         user = getattr(_thread_local, 'user', None)
-        user_prefix = f" [{process_message_substitutions(user)}]" if user else ""
+        user_prefix = f" [{user}]" if user else ""
 
         # If we just printed a partial line (no newline), add one before the debug message to avoid clobbering
         if getattr(_thread_local, 'in_partial_line', False):
             print()
             _thread_local.in_partial_line = False
 
-        print(f"[DEBUG {timestamp}]{user_prefix} {message}")
+        print(apply_privacy_substitutions(f"[DEBUG {timestamp}]{user_prefix} {message}"))
 
 
 # Initializes the CSV file
@@ -5375,6 +5385,8 @@ def generate_user_dashboard(target_data):
     if not RICH_AVAILABLE:
         return None
 
+    target_data = apply_privacy_substitutions(target_data)
+
     # Type guard: Rich is available at this point
     assert Table is not None
     assert box is not None
@@ -5536,6 +5548,9 @@ def generate_user_dashboard(target_data):
 def generate_config_dashboard(target_data, config_data):
     if not RICH_AVAILABLE:
         return None
+
+    target_data = apply_privacy_substitutions(target_data)
+    config_data = apply_privacy_substitutions(config_data)
 
     # Type guard: Rich is available at this point
     assert Table is not None

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -1726,7 +1726,8 @@ def create_web_dashboard_app():
                 'dashboard_show_check_seconds': DASHBOARD_SHOW_CHECK_SECONDS,
             }
             data = apply_privacy_substitutions(data)
-            return jsonify(data)
+            jsonify_func = cast(Callable[..., Any], jsonify)
+            return jsonify_func(data)
         elif flask_request.method == 'POST':  # type: ignore
             data = flask_request.get_json(silent=True) or {}  # type: ignore
             ok, changes, err, code = apply_settings_update(data)
@@ -2186,10 +2187,11 @@ def stop_monitoring_for_target(username):
 
     # Clean up thread reference - wait for thread to finish with timeout
     if username in WEB_DASHBOARD_MONITOR_THREADS:
-        thread = WEB_DASHBOARD_MONITOR_THREADS[username]
-        can_join = (thread is not None and thread.is_alive() and thread is not threading.current_thread() and thread is not threading.main_thread())
-        if can_join:
-            thread.join(timeout=5.0)  # Wait up to 5 seconds for clean shutdown
+        thread = WEB_DASHBOARD_MONITOR_THREADS.get(username)
+        if isinstance(thread, threading.Thread):
+            can_join = thread.is_alive() and thread is not threading.current_thread() and thread is not threading.main_thread()
+            if can_join:
+                thread.join(timeout=5.0)  # Wait up to 5 seconds for clean shutdown
         del WEB_DASHBOARD_MONITOR_THREADS[username]
     if username in WEB_DASHBOARD_STOP_EVENTS:
         del WEB_DASHBOARD_STOP_EVENTS[username]

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -3702,7 +3702,6 @@ def process_message_substitutions(message: str) -> str:
             message = str(message)
         for search, replace in PRIVACY_SUBSTITIONS:
             message = message.replace(search, replace)
-
     return message
 
    

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -184,7 +184,7 @@ JITTER_VERBOSE = False
 # Optional Privacy Substitutions
 # This allows you to substitute any string for another in all messaging, logging, webhooks, emails, and both dashboards.
 # For instance, you may want to change a particular Instagram username to a more friendly name, or you could mask a name.
-# 
+#
 # Provide a list of (search, replace) tuples. Any search term will be substituted with the replace term.
 #
 # Example:
@@ -858,7 +858,7 @@ except ModuleNotFoundError:
 from instaloader.exceptions import PrivateProfileNotFollowedException
 from html import escape
 from itertools import islice
-from typing import Optional, Tuple, Any, Callable, List
+from typing import Optional, Tuple, Any, Callable, List, TypeVar, cast
 from glob import glob
 import sqlite3
 from sqlite3 import OperationalError, connect
@@ -3701,9 +3701,12 @@ def refresh_proxy_if_needed(bot, user):
                 log_activity(f"Proxy refresh failed: {error_msg}", user=user, level='error')
 
 
-def apply_privacy_substitutions(content):
+TPrivacyContent = TypeVar("TPrivacyContent")
+
+
+# Apply PRIVACY_SUBSTITIONS to any content type
+def apply_privacy_substitutions(content: TPrivacyContent) -> TPrivacyContent:
     """
-    Apply PRIVACY_SUBSTITIONS to any content type.
     - Recurses into dict values and list items
     - For strings, performs search/replace using PRIVACY_SUBSTITIONS
     - Preserves dictionary keys to keep API object identity stable
@@ -3714,6 +3717,7 @@ def apply_privacy_substitutions(content):
     if not PRIVACY_SUBSTITIONS:
         return content
     if isinstance(content, str):
+        content_str = content
         for item in PRIVACY_SUBSTITIONS:
             if not isinstance(item, (list, tuple)) or len(item) != 2:
                 if not PRIVACY_SUBSTITIONS_INVALID_WARNED:
@@ -3728,14 +3732,14 @@ def apply_privacy_substitutions(content):
                         sys.__stderr__.write("* Warning: Ignoring invalid PRIVACY_SUBSTITIONS entry, expected non-empty string search and string replace values\n")
                     PRIVACY_SUBSTITIONS_INVALID_WARNED = True
                 continue
-            content = content.replace(search, replace)
-        return content
+            content_str = content_str.replace(search, replace)
+        return cast(TPrivacyContent, content_str)
     if isinstance(content, dict):
-        return {k: apply_privacy_substitutions(v) for k, v in content.items()}
+        return cast(TPrivacyContent, {k: apply_privacy_substitutions(v) for k, v in content.items()})
     if isinstance(content, list):
-        return [apply_privacy_substitutions(item) for item in content]
+        return cast(TPrivacyContent, [apply_privacy_substitutions(item) for item in content])
     return content
-    
+
 
 # Debug print helper - only prints if DEBUG_MODE is enabled
 def debug_print(message):

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -3497,39 +3497,43 @@ def send_webhook(title, description, color=0x7289DA, fields=None, image_url=None
 
     for attempt in range(max_retries):
         try:
+            sanitized_fields = []
+            if fields:
+                for field in fields[:WEBHOOK_MAX_FIELDS]:  # type: ignore
+                    sanitized_name = apply_privacy_substitutions(str(field.get("name", "")))  # type: ignore
+                    sanitized_value = apply_privacy_substitutions(str(field.get("value", "")))  # type: ignore
+                    sanitized_fields.append({
+                        "name": sanitized_name[:WEBHOOK_FIELD_NAME_LIMIT],  # type: ignore
+                        "value": sanitized_value[:WEBHOOK_FIELD_VALUE_LIMIT],  # type: ignore
+                        "inline": field.get("inline", False)
+                    })
+
+            sanitized_image_url = apply_privacy_substitutions(str(image_url)) if image_url else ""
+
             # Load all possible items into payload for use in formatting the WEBHOOK_TEMPLATE and WEBHOOK_HEADERS
             payload = {
                 "title": title[:WEBHOOK_EMBED_TITLE_LIMIT] if title else "Instagram Monitor",  # type: ignore
                 "description": description[:WEBHOOK_EMBED_DESCRIPTION_LIMIT] if description else "",  # type: ignore
                 "version": VERSION,
-                "image_url": image_url if image_url else "",
-                "fields": fields if fields else [],
-                "fields_str": "\n".join([f"{f['name']}: {f['value']}" for f in fields]) if fields else "",
+                "image_url": sanitized_image_url,
+                "fields": sanitized_fields,
+                "fields_str": "\n".join([f"{f['name']}: {f['value']}" for f in sanitized_fields]) if sanitized_fields else "",
                 "color": color,
                 "timestamp": datetime.now(timezone.utc).isoformat()
             }
 
-            if fields:
-                payload["fields"] = []
-                for field in fields[:WEBHOOK_MAX_FIELDS]:  # type: ignore
-                    payload["fields"].append({
-                        "name": str(field.get("name", ""))[:WEBHOOK_FIELD_NAME_LIMIT],  # type: ignore
-                        "value": str(field.get("value", ""))[:WEBHOOK_FIELD_VALUE_LIMIT],  # type: ignore
-                        "inline": field.get("inline", False)
-                    })
-
-            if image_url:
-                payload["image"] = {"url": image_url}
+            if sanitized_image_url:
+                payload["image"] = {"url": sanitized_image_url}
             elif local_image_file and os.path.isfile(local_image_file):
                 # If using local file, use attachment:// syntax
                 filename = os.path.basename(local_image_file)
                 payload["image"] = {"url": f"attachment://{filename}"}
 
             if WEBHOOK_USERNAME:
-                payload["username"] = WEBHOOK_USERNAME
+                payload["username"] = apply_privacy_substitutions(str(WEBHOOK_USERNAME))
 
             if WEBHOOK_AVATAR_URL:
-                payload["avatar_url"] = WEBHOOK_AVATAR_URL
+                payload["avatar_url"] = apply_privacy_substitutions(str(WEBHOOK_AVATAR_URL))
 
             # Apply optional transformations to payload, primarily the title and description
             for transform in WEBHOOK_TRANSFORMS:  # type: ignore

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -724,6 +724,7 @@ LIVENESS_CHECK_COUNTER = 0
 stdout_bck = None
 last_output = []
 csvfieldnames = ['Date', 'Type', 'Old', 'New']
+PRIVACY_SUBSTITIONS_INVALID_WARNED = False
 
 imgcat_exe = ""
 
@@ -3702,12 +3703,27 @@ def apply_privacy_substitutions(content):
     - Recurses into dict values and list items
     - For strings, performs search/replace using PRIVACY_SUBSTITIONS
     - Preserves dictionary keys to keep API object identity stable
+    - Ignores invalid substitution entries to avoid runtime crashes
     - Non-string primitives are returned unchanged
     """
+    global PRIVACY_SUBSTITIONS_INVALID_WARNED
     if not PRIVACY_SUBSTITIONS:
         return content
     if isinstance(content, str):
-        for search, replace in PRIVACY_SUBSTITIONS:
+        for item in PRIVACY_SUBSTITIONS:
+            if not isinstance(item, (list, tuple)) or len(item) != 2:
+                if not PRIVACY_SUBSTITIONS_INVALID_WARNED:
+                    if sys.__stderr__ is not None:
+                        sys.__stderr__.write("* Warning: Ignoring invalid PRIVACY_SUBSTITIONS entry, expected (search, replace) with both values as strings\n")
+                    PRIVACY_SUBSTITIONS_INVALID_WARNED = True
+                continue
+            search, replace = item
+            if not isinstance(search, str) or not isinstance(replace, str) or not search:
+                if not PRIVACY_SUBSTITIONS_INVALID_WARNED:
+                    if sys.__stderr__ is not None:
+                        sys.__stderr__.write("* Warning: Ignoring invalid PRIVACY_SUBSTITIONS entry, expected non-empty string search and string replace values\n")
+                    PRIVACY_SUBSTITIONS_INVALID_WARNED = True
+                continue
             content = content.replace(search, replace)
         return content
     if isinstance(content, dict):

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -182,7 +182,7 @@ ENABLE_JITTER = False
 JITTER_VERBOSE = False
 
 # Optional Privacy Substitutions
-# This allows you to substitute any string for another in all messaging, logging, webhooks, and emails.
+# This allows you to substitute any string for another in all messaging, logging, webhooks, emails, and both dashboards.
 # For instance, you may want to change a particular Instagram username to a more friendly name, or you could mask a name.
 # 
 # Provide a list of (search, replace) tuples. Any search term will be substituted with the replace term.

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -3709,11 +3709,24 @@ def refresh_proxy_if_needed(bot, user):
                 log_activity(f"Proxy refresh failed: {error_msg}", user=user, level='error')
 
 
+def process_message_substitutions(message: str) -> str:
+    """
+    Perform search/replace on a message using the PRIVACY_SUBSTITIONS global variable.
+    PRIVACY_SUBSTITIONS should be a list of (search, replace) tuples.
+    Returns the original message if PRIVACY_SUBSTITIONS doesn't exist or is empty.
+    """
+    if PRIVACY_SUBSTITIONS:
+        if not isinstance(message, str):
+            message = str(message)
+        for search, replace in PRIVACY_SUBSTITIONS:
+            message = message.replace(search, replace)
+
+    return message
+
+   
 # Debug print helper - only prints if DEBUG_MODE is enabled
 def debug_print(message):
     if DEBUG_MODE:
-        if not isinstance(message, str):
-            message = str(message)
         message = process_message_substitutions(message)
         timestamp = get_hour_min_from_ts(now_local(), show_seconds=True)
         user = getattr(_thread_local, 'user', None)

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -3494,6 +3494,8 @@ def process_message_substitutions(message: str) -> str:
 # Debug print helper - only prints if DEBUG_MODE is enabled
 def debug_print(message):
     if DEBUG_MODE:
+        if not isinstance(message, str):
+            message = str(message)
         message = process_message_substitutions(message)
         timestamp = get_hour_min_from_ts(now_local(), show_seconds=True)
         user = getattr(_thread_local, 'user', None)

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -3601,24 +3601,6 @@ def send_webhook(title, description, color=0x7289DA, fields=None, image_url=None
     return 1
 
 
-def process_message_substitutions(message: str) -> str:
-    """
-    Perform search/replace on a message using the PRIVACY_SUBSTITIONS global variable.
-    PRIVACY_SUBSTITIONS should be a list of (search, replace) tuples.
-    Returns the original message if PRIVACY_SUBSTITIONS doesn't exist or is empty.
-    """
-    try:
-        if not PRIVACY_SUBSTITIONS:
-            return message
-    except NameError:
-        return message
-
-    for search, replace in PRIVACY_SUBSTITIONS:
-        message = message.replace(search, replace)
-
-    return message
-
-   
 # Fetches the current outbound IP via IP_ADDRESS_URL, tolerating JSON and plain-text responses
 def get_ip_address(max_retries=3, timeout=10):
     last_err = None


### PR DESCRIPTION
```
# Optional Privacy Substitutions
# This allows you to substitute any string for another in all messaging, logging, webhooks, emails, and both dashboards.
# For instance, you may want to change a particular Instagram username to a more friendly name, or you could mask a name.
# 
# Provide a list of (search, replace) tuples. Any search term will be substituted with the replace term.
#
# Example:
# PRIVACY_SUBSTITIONS = [ ("a.username", "XXX"), ("sdfsdf747475475", "Bobby") ]
#
PRIVACY_SUBSTITIONS = [ ]
```