### PR TITLE
Option to skip wrap messages during monkey-patching

### DIFF
--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -706,6 +706,7 @@ FOLLOWERS_CHURN_DETECTION = False
 TIME_FORMAT_12H = False
 PRIVACY_SUBSTITIONS = []
 mode_of_the_tool = "Unknown"
+SKIP_WRAP_MESSAGES = False
 
 exec(CONFIG_BLOCK, globals())
 
@@ -6128,10 +6129,11 @@ def instagram_wrap_request(orig_request):
         if method and isinstance(method, str):
             method = method.upper()
         url = kwargs.get("url") or (args[2] if len(args) > 2 else None)
-        if DEBUG_MODE:
-            debug_print(f"[WRAP-REQ] {method} {url}")
-        elif JITTER_VERBOSE:
-            print(f"* [WRAP-REQ] {method} {url}")
+        if not SKIP_WRAP_MESSAGES:
+            if DEBUG_MODE:
+                debug_print(f"[WRAP-REQ] {method} {url}")
+            elif JITTER_VERBOSE:
+                print(f"* [WRAP-REQ] {method} {url}")
 
         def _do_request():
             # If jitter is disabled, just perform the request (but still optionally serialized by the outer lock)
@@ -6259,10 +6261,11 @@ def instagram_wrap_send(orig_send):
         if method and isinstance(method, str):
             method = method.upper()
         url = getattr(req_obj, "url", None)
-        if DEBUG_MODE:
-            debug_print(f"[WRAP-SEND] {method} {url}")
-        elif JITTER_VERBOSE:
-            print(f"* [WRAP-SEND] {method} {url}")
+        if not SKIP_WRAP_MESSAGES:
+            if DEBUG_MODE:
+                debug_print(f"[WRAP-SEND] {method} {url}")
+            elif JITTER_VERBOSE:
+                print(f"* [WRAP-SEND] {method} {url}")
 
         def _do_send():
             if ENABLE_JITTER:

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -181,6 +181,10 @@ ENABLE_JITTER = False
 # Set to True to enable verbose output for HTTP jitter/back-off wrappers
 JITTER_VERBOSE = False
 
+# Set to True to skip the per-request WRAP-REQ/WRAP-SEND log lines from the HTTP jitter/back-off wrappers
+# These can be overwhelming in debug or jitter-verbose mode and are not needed in most cases
+SKIP_WRAP_MESSAGES = False
+
 # Optional Privacy Substitutions
 # This allows you to substitute any string for another in all messaging, logging, webhooks, emails, and both dashboards.
 # For instance, you may want to change a particular Instagram username to a more friendly name, or you could mask a name.
@@ -654,6 +658,7 @@ MY_HASHTAGS = []
 BE_HUMAN_VERBOSE = False
 ENABLE_JITTER = False
 JITTER_VERBOSE = False
+SKIP_WRAP_MESSAGES = False
 LIVENESS_CHECK_INTERVAL = 0
 CHECK_INTERNET_URL = ""
 CHECK_INTERNET_TIMEOUT = 0
@@ -706,7 +711,6 @@ FOLLOWERS_CHURN_DETECTION = False
 TIME_FORMAT_12H = False
 PRIVACY_SUBSTITIONS = []
 mode_of_the_tool = "Unknown"
-SKIP_WRAP_MESSAGES = False
 
 exec(CONFIG_BLOCK, globals())
 


### PR DESCRIPTION
This adds an option to skip the WRAP-REQ and WRAP-SEND messages when monkey-patched code is executing.
It can be overwhelming and is not needed for many cases. 
Thsi is an optional method for developers to turn them off (put SKIP_WRAP_MESSAGES = True in .conf file)
Don't need to document or have a command line option..
