### PR TITLE
Better messaging for flagged accounts

### DIFF
--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -5331,7 +5331,7 @@ def update_check_times(last_time=None, next_time=None, user=None, increment_coun
         DASHBOARD_DATA['config'] = get_dashboard_config_data()
         update_dashboard()
 
-    if WEB_DASHBOARD_ENABLED:
+    if WEB_DASHBOARD_ENABLED or DASHBOARD_ENABLED:
         last_display = get_squeezed_date_from_ts(LAST_CHECK_TIME, show_seconds=DASHBOARD_SHOW_CHECK_SECONDS) if LAST_CHECK_TIME else None
         next_display = get_squeezed_date_from_ts(NEXT_CHECK_TIME, show_seconds=DASHBOARD_SHOW_CHECK_SECONDS) if NEXT_CHECK_TIME else (NEXT_CHECK_DISPLAY or None)
 
@@ -6836,7 +6836,7 @@ def fetch_usernames_paginated(bot, get_generator_fn, max_per_batch, total_limit,
 
 # Monitors activity of the specified Instagram user
 def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, skip_followings, skip_getting_story_details, skip_getting_posts_details, get_more_post_details, wait_for_prev_user=None, signal_loading_complete=None, stop_event=None, user_root_path=None, manual_recheck=False, skip_follow_changes=False):  # type: ignore[reportComplexity]
-    global pbar, DASHBOARD_DATA, VERBOSE_MODE, CHECK_COUNT
+    global pbar, DASHBOARD_DATA, VERBOSE_MODE, CHECK_COUNT, NEXT_CHECK_TIME, NEXT_CHECK_DISPLAY
     _thread_local.user = user  # Store user in thread-local storage for debug_print
     _thread_local.in_partial_line = False  # Track partial line prints
     update_ui_data(targets={user: {'status': 'Starting'}})
@@ -7116,49 +7116,62 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
         log_activity(f"Error: {error_msg}", user=user)
 
         # Handle session recovery for automated checks/challenge errors
-        if WEB_DASHBOARD_ENABLED and any(t in error_msg for t in FLAGGED_TRIGGERS):
-            if threading.current_thread() is not threading.main_thread():
-                update_ui_data(targets={user: {'status': 'Paused: Session re-login required'}})
-                log_activity("Monitoring paused: Session re-login required via Web Dashboard", user=user)
-                print(f"* Monitoring paused for {user}. Please refresh/import session via Web Dashboard.")
-                log_activity(f"Account '{SESSION_USERNAME or '<anonymous>'}' is flagged by Instagram. You must log in and clear any warnings.", user=user)
-                print(f"* Error: Account '{SESSION_USERNAME or '<anonymous>'}' is flagged by Instagram. You must log in and clear any warnings.")
+        if any(t in error_msg for t in FLAGGED_TRIGGERS):
+            err_str = f"Session account '{SESSION_USERNAME or '<anonymous>'}' has been flagged. Log into Instagram and clear warnings."
+            update_ui_data(targets={user: {'status': f'Paused: {err_str}'}})
+            print(f"* Error: {err_str}")
+            
+            # Pause all other threads once the session account is flagged.
+            if WEB_DASHBOARD_ENABLED or DASHBOARD_ENABLED:
+                for other_user in list(WEB_DASHBOARD_STOP_EVENTS.keys()):
+                    if other_user != user:
+                        log_activity(err_str, user=other_user)
+                        update_check_times(next_time="Paused", user=other_user, increment_count=False)
+                        stop_monitoring_for_target(other_user)
+                        update_ui_data(targets={other_user: {'status': f'Paused: {err_str}'}})
+                # Update next_check status for this thread
+                NEXT_CHECK_TIME = None  
+                NEXT_CHECK_DISPLAY = "Paused"
+                update_check_times(next_time="Paused", user=user, increment_count=False)
+                # Pause this thread also
+                log_activity("Stopping monitoring", user=user)
                 print_cur_ts("\nTimestamp:\t\t\t\t")
             else:
-                update_ui_data(targets={user: {'status': 'Main Instagram account flagged for automation. Exiting script.'}})
-                log_activity(f"Account '{SESSION_USERNAME or '<anonymous>'}' is flagged by Instagram for automation. You must log in and clear any warnings.", user=user)
-                log_activity(f"Exiting script", user=user)
-                print(f"* Error: Account {SESSION_USERNAME} is flagged by Instagram for automation. You must log in and clear any warnings. Exiting script.")
-                sys.exit(1)
+                print_cur_ts("\nTimestamp:\t\t\t\t")
+                signal_handler(signal.SIGINT, None, message='')
 
             # Wait for session refresh or stop event
-            while not (stop_event and stop_event.is_set()):
-                if SESSION_REFRESHED_EVENT.wait(timeout=1.0):
-                    # Session refreshed! Reload and retry
-                    log_activity("Session/Mode change detected, resuming monitoring...", user=user)
-                    print(f"* Session/Mode change detected for {user}, resuming...")
-                    print_cur_ts("\nTimestamp:\t\t\t\t")
+            if WEB_DASHBOARD_ENABLED:
+                while not (stop_event and stop_event.is_set()):
+                    if SESSION_REFRESHED_EVENT.wait(timeout=1.0):
+                        # Session refreshed! Reload and retry
+                        log_activity("Session/Mode change detected, resuming monitoring...", user=user)
+                        print(f"* Session/Mode change detected for {user}, resuming...")
+                        print_cur_ts("\nTimestamp:\t\t\t\t")
 
-                    # Refresh configuration from global settings
-                    skip_session = SKIP_SESSION
-                    skip_followers = SKIP_FOLLOWERS
-                    skip_followings = SKIP_FOLLOWINGS
-                    skip_getting_story_details = SKIP_GETTING_STORY_DETAILS
-                    skip_getting_posts_details = SKIP_GETTING_POSTS_DETAILS
-                    get_more_post_details = GET_MORE_POST_DETAILS
+                        # Refresh configuration from global settings
+                        skip_session = SKIP_SESSION
+                        skip_followers = SKIP_FOLLOWERS
+                        skip_followings = SKIP_FOLLOWINGS
+                        skip_getting_story_details = SKIP_GETTING_STORY_DETAILS
+                        skip_getting_posts_details = SKIP_GETTING_POSTS_DETAILS
+                        get_more_post_details = GET_MORE_POST_DETAILS
 
-                    # Re-run the function from the beginning to reset state with new settings
-                    return instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, skip_followings, skip_getting_story_details, skip_getting_posts_details, get_more_post_details, wait_for_prev_user, signal_loading_complete, stop_event, user_root_path, manual_recheck)
+                        # Re-run the function from the beginning to reset state with new settings
+                        return instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, skip_followings, skip_getting_story_details, skip_getting_posts_details, get_more_post_details, wait_for_prev_user, signal_loading_complete, stop_event, user_root_path, manual_recheck)
 
-            if stop_event and stop_event.is_set():
-                return
+                if stop_event and stop_event.is_set():
+                    return
+        else:
+            print_cur_ts("\nTimestamp:\t\t\t\t")
 
         if WEB_DASHBOARD_ENABLED:
             update_ui_data(targets={user: {'status': 'Error: ' + error_msg}})
-
         if threading.current_thread() is threading.main_thread():
+            time.sleep(2)  # let terminal dashboard fully refresh logs/status in case this generates a script exit
             sys.exit(1)
         else:
+            time.sleep(2)  # let terminal dashboard fully refresh logs/status in case this generates a script exit
             return
 
     story_flag = False
@@ -8180,20 +8193,32 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
                             notification_type="error"
                         )
 
-                if WEB_DASHBOARD_ENABLED and any(t in error_msg for t in FLAGGED_TRIGGERS):
-                    if threading.current_thread() is not threading.main_thread():
-                        update_ui_data(targets={user: {'status': 'Paused: Session re-login required'}})
-                        log_activity("Monitoring paused: Session re-login required via Web Dashboard", user=user)
-                        print(f"* Monitoring paused for {user}. Please refresh/import session via Web Dashboard.")
-                        log_activity(f"Account '{SESSION_USERNAME or '<anonymous>'}' is flagged by Instagram. You must log in and clear any warnings.", user=user)
-                        print(f"* Error: Account '{SESSION_USERNAME or '<anonymous>'}' is flagged by Instagram. You must log in and clear any warnings.")
+                # Handle session recovery for automated checks/challenge errors
+                if any(t in error_msg for t in FLAGGED_TRIGGERS):
+                    err_str = f"Session account '{SESSION_USERNAME or '<anonymous>'}' has been flagged. Log into Instagram and clear warnings."
+                    for i in range(50):
+                        log_activity(f"({i}) - {err_str}", user=user)
+                    update_ui_data(targets={user: {'status': f'Paused: {err_str}'}})
+                    print(f"* Error: {err_str}")
+                    
+                    # Pause all other threads once the session account is flagged.
+                    if WEB_DASHBOARD_ENABLED or DASHBOARD_ENABLED:
+                        for other_user in list(WEB_DASHBOARD_STOP_EVENTS.keys()):
+                            if other_user != user:
+                                log_activity(err_str, user=other_user)
+                                update_check_times(next_time="Paused", user=other_user, increment_count=False)
+                                stop_monitoring_for_target(other_user)
+                                update_ui_data(targets={other_user: {'status': f'Paused: {err_str}'}})
+                        # Update next_check status for this thread
+                        NEXT_CHECK_TIME = None  
+                        NEXT_CHECK_DISPLAY = "Paused"
+                        update_check_times(next_time="Paused", user=user, increment_count=False)
+                        # Pause this thread also
+                        log_activity("Stopping monitoring", user=user)
                         print_cur_ts("\nTimestamp:\t\t\t\t")
                     else:
-                        update_ui_data(targets={user: {'status': 'Main Instagram account flagged for automation. Exiting script.'}})
-                        log_activity(f"Account '{SESSION_USERNAME or '<anonymous>'}' is flagged by Instagram for automation. You must log in and clear any warnings.", user=user)
-                        log_activity(f"Exiting script", user=user)
-                        print(f"* Error: Account {SESSION_USERNAME} is flagged by Instagram for automation. You must log in and clear any warnings. Exiting script.")
-                        sys.exit(1)
+                        print_cur_ts("\nTimestamp:\t\t\t\t")
+                        signal_handler(signal.SIGINT, None, message='')
 
                     # Wait for session refresh or stop event
                     while not (stop_event and stop_event.is_set()):
@@ -10754,6 +10779,9 @@ def run_main():
                 # Still signal completion even on error, so next user can proceed
                 loading_events[idx + 1].set()
             finally:
+                # next code line added per Claude to fix 'deadlock' in multi-threaded mode when an account gets flagged and goes idle
+                # reason: loading_events never signaled on early return (note: event.set() is idempotent so calling it twice is harmless)
+                loading_events[idx + 1].set()  
                 with WEB_DASHBOARD_DATA_LOCK:  # type: ignore
                     if u in WEB_DASHBOARD_RECHECK_EVENTS:
                         del WEB_DASHBOARD_RECHECK_EVENTS[u]
@@ -10779,6 +10807,7 @@ def run_main():
                     # but if we're here, we ensure clean exit
                     signal_handler(signal.SIGINT, None)
 
+    # this is for main thread to handle the web interface
     if WEB_DASHBOARD_ENABLED:
         try:
             while True:

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -7149,7 +7149,7 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
 
         if WEB_DASHBOARD_ENABLED:
             update_ui_data(targets={user: {'status': 'Error: ' + error_msg}})
-        # traceback.print_exc()
+
         if threading.current_thread() is threading.main_thread():
             sys.exit(1)
         else:

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -743,8 +743,8 @@ DEFAULT_CONFIG_FILENAME = "instagram_monitor.conf"
 # List of secret keys to load from env/config
 SECRET_KEYS = ("SESSION_PASSWORD", "SMTP_PASSWORD", "WEBHOOK_URL", "PROXY_URL")
 
-# List of error messages indicating an Instagram has been flagged for 'automation' or 'botting'
-FLAGGED_TRIGGERS = ("detected automated checks", "ProfileNotExistsException", "cannot access local variable", "checkpoint_required")
+# List of error substrings that unambiguously indicate the session account or IP has been flagged (challenge/checkpoint/shadowban)
+FLAGGED_TRIGGERS = ("detected automated checks", "checkpoint_required")
 
 # Default value for network-related timeouts in functions
 FUNCTION_TIMEOUT = 15
@@ -7133,14 +7133,14 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
                 NEXT_CHECK_TIME = None  
                 NEXT_CHECK_DISPLAY = "Paused"
                 update_check_times(next_time="Paused", user=user, increment_count=False)
-                # Pause this thread also
                 log_activity("Stopping monitoring", user=user)
-                print_cur_ts("\nTimestamp:\t\t\t\t")
-            else:
-                print_cur_ts("\nTimestamp:\t\t\t\t")
+            print_cur_ts("\nTimestamp:\t\t\t\t")
+
+            # Without the Web Dashboard there is no in-place session recovery so exit since the flagged session is dead for every target
+            if not WEB_DASHBOARD_ENABLED:
                 signal_handler(signal.SIGINT, None, message='')
 
-            # Wait for session refresh or stop event
+            # Web Dashboard can re-import a session and resume, so wait for that or a stop event
             if WEB_DASHBOARD_ENABLED:
                 while not (stop_event and stop_event.is_set()):
                     if SESSION_REFRESHED_EVENT.wait(timeout=1.0):
@@ -8196,8 +8196,6 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
                 # Handle session recovery for automated checks/challenge errors
                 if any(t in error_msg for t in FLAGGED_TRIGGERS):
                     err_str = f"Session account '{SESSION_USERNAME or '<anonymous>'}' has been flagged. Log into Instagram and clear warnings."
-                    for i in range(50):
-                        log_activity(f"({i}) - {err_str}", user=user)
                     update_ui_data(targets={user: {'status': f'Paused: {err_str}'}})
                     print(f"* Error: {err_str}")
                     
@@ -8213,14 +8211,14 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
                         NEXT_CHECK_TIME = None  
                         NEXT_CHECK_DISPLAY = "Paused"
                         update_check_times(next_time="Paused", user=user, increment_count=False)
-                        # Pause this thread also
                         log_activity("Stopping monitoring", user=user)
-                        print_cur_ts("\nTimestamp:\t\t\t\t")
-                    else:
-                        print_cur_ts("\nTimestamp:\t\t\t\t")
+                    print_cur_ts("\nTimestamp:\t\t\t\t")
+
+                    # Without the Web Dashboard there is no in-place session recovery so exit since the flagged session is dead for every target
+                    if not WEB_DASHBOARD_ENABLED:
                         signal_handler(signal.SIGINT, None, message='')
 
-                    # Wait for session refresh or stop event
+                    # Web Dashboard can re-import a session and resume, so wait for that or a stop event
                     while not (stop_event and stop_event.is_set()):
                         if SESSION_REFRESHED_EVENT.wait(timeout=1.0):
                             # Session refreshed!

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -7113,11 +7113,17 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
         log_activity(f"Error: {error_msg}", user=user)
 
         # Handle session recovery for automated checks/challenge errors
-        if "detected automated checks" in error_msg and WEB_DASHBOARD_ENABLED:
+        if WEB_DASHBOARD_ENABLED and ("detected automated checks" in error_msg or "ProfileNotExistsException" in error_msg or "cannot access local variable" in error_msg):
             update_ui_data(targets={user: {'status': 'Paused: Session re-login required'}})
             log_activity("Monitoring paused: Session re-login required via Web Dashboard", user=user)
             print(f"* Monitoring paused for {user}. Please refresh/import session via Web Dashboard.")
+            if ("ProfileNotExistsException" in error_msg or "cannot access local variable" in error_msg):
+                log_activity(f"ProfileNotExistsException: If account '{user}' is correct, then '{SESSION_USERNAME or '<anonymous>'}' is likely shadowbanned and unusable.", user=user)
+                print(f"* ProfileNotExistsException: If account '{user}' is correct, then '{SESSION_USERNAME or '<anonymous>'}' is likely shadowbanned and unusable.")
             print_cur_ts("\nTimestamp:\t\t\t\t")
+
+            if threading.current_thread() is threading.main_thread():
+                sys.exit(1)
 
             # Wait for session refresh or stop event
             while not (stop_event and stop_event.is_set()):
@@ -8168,11 +8174,17 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
                             notification_type="error"
                         )
 
-                if "detected automated checks" in error_msg and WEB_DASHBOARD_ENABLED:
+                if WEB_DASHBOARD_ENABLED and ("detected automated checks" in error_msg or "ProfileNotExistsException" in error_msg or "cannot access local variable" in error_msg):
                     update_ui_data(targets={user: {'status': 'Paused: Session re-login required'}})
                     log_activity("Monitoring paused: Session re-login required via Web Dashboard", user=user)
                     print(f"* Monitoring paused for {user}. Please refresh/import session via Web Dashboard.")
+                    if ("ProfileNotExistsException" in error_msg or "cannot access local variable" in error_msg):
+                        log_activity(f"ProfileNotExistsException: If account '{user}' is correct, then '{SESSION_USERNAME or '<anonymous>'}' is likely shadowbanned and unusable.", user=user)
+                        print(f"* ProfileNotExistsException: If account '{user}' is correct, then '{SESSION_USERNAME or '<anonymous>'}' is likely shadowbanned and unusable.")
                     print_cur_ts("\nTimestamp:\t\t\t\t")
+
+                    if threading.current_thread() is threading.main_thread():
+                        sys.exit(1)
 
                     # Wait for session refresh or stop event
                     while not (stop_event and stop_event.is_set()):

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -743,6 +743,9 @@ DEFAULT_CONFIG_FILENAME = "instagram_monitor.conf"
 # List of secret keys to load from env/config
 SECRET_KEYS = ("SESSION_PASSWORD", "SMTP_PASSWORD", "WEBHOOK_URL", "PROXY_URL")
 
+# List of error messages indicating an Instagram has been flagged for 'automation' or 'botting'
+FLAGGED_TRIGGERS = ("detected automated checks", "ProfileNotExistsException", "cannot access local variable", "checkpoint_required")
+
 # Default value for network-related timeouts in functions
 FUNCTION_TIMEOUT = 15
 
@@ -7113,16 +7116,19 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
         log_activity(f"Error: {error_msg}", user=user)
 
         # Handle session recovery for automated checks/challenge errors
-        if WEB_DASHBOARD_ENABLED and ("detected automated checks" in error_msg or "ProfileNotExistsException" in error_msg or "cannot access local variable" in error_msg):
-            update_ui_data(targets={user: {'status': 'Paused: Session re-login required'}})
-            log_activity("Monitoring paused: Session re-login required via Web Dashboard", user=user)
-            print(f"* Monitoring paused for {user}. Please refresh/import session via Web Dashboard.")
-            if ("ProfileNotExistsException" in error_msg or "cannot access local variable" in error_msg):
-                log_activity(f"ProfileNotExistsException: If account '{user}' is correct, then '{SESSION_USERNAME or '<anonymous>'}' is likely shadowbanned and unusable.", user=user)
-                print(f"* ProfileNotExistsException: If account '{user}' is correct, then '{SESSION_USERNAME or '<anonymous>'}' is likely shadowbanned and unusable.")
-            print_cur_ts("\nTimestamp:\t\t\t\t")
-
-            if threading.current_thread() is threading.main_thread():
+        if WEB_DASHBOARD_ENABLED and any(t in error_msg for t in FLAGGED_TRIGGERS):
+            if threading.current_thread() is not threading.main_thread():
+                update_ui_data(targets={user: {'status': 'Paused: Session re-login required'}})
+                log_activity("Monitoring paused: Session re-login required via Web Dashboard", user=user)
+                print(f"* Monitoring paused for {user}. Please refresh/import session via Web Dashboard.")
+                log_activity(f"Account '{SESSION_USERNAME or '<anonymous>'}' is flagged by Instagram. You must log in and clear any warnings.", user=user)
+                print(f"* Error: Account '{SESSION_USERNAME or '<anonymous>'}' is flagged by Instagram. You must log in and clear any warnings.")
+                print_cur_ts("\nTimestamp:\t\t\t\t")
+            else:
+                update_ui_data(targets={user: {'status': 'Main Instagram account flagged for automation. Exiting script.'}})
+                log_activity(f"Account '{SESSION_USERNAME or '<anonymous>'}' is flagged by Instagram for automation. You must log in and clear any warnings.", user=user)
+                log_activity(f"Exiting script", user=user)
+                print(f"* Error: Account {SESSION_USERNAME} is flagged by Instagram for automation. You must log in and clear any warnings. Exiting script.")
                 sys.exit(1)
 
             # Wait for session refresh or stop event
@@ -8174,16 +8180,19 @@ def instagram_monitor_user(user, csv_file_name, skip_session, skip_followers, sk
                             notification_type="error"
                         )
 
-                if WEB_DASHBOARD_ENABLED and ("detected automated checks" in error_msg or "ProfileNotExistsException" in error_msg or "cannot access local variable" in error_msg):
-                    update_ui_data(targets={user: {'status': 'Paused: Session re-login required'}})
-                    log_activity("Monitoring paused: Session re-login required via Web Dashboard", user=user)
-                    print(f"* Monitoring paused for {user}. Please refresh/import session via Web Dashboard.")
-                    if ("ProfileNotExistsException" in error_msg or "cannot access local variable" in error_msg):
-                        log_activity(f"ProfileNotExistsException: If account '{user}' is correct, then '{SESSION_USERNAME or '<anonymous>'}' is likely shadowbanned and unusable.", user=user)
-                        print(f"* ProfileNotExistsException: If account '{user}' is correct, then '{SESSION_USERNAME or '<anonymous>'}' is likely shadowbanned and unusable.")
-                    print_cur_ts("\nTimestamp:\t\t\t\t")
-
-                    if threading.current_thread() is threading.main_thread():
+                if WEB_DASHBOARD_ENABLED and any(t in error_msg for t in FLAGGED_TRIGGERS):
+                    if threading.current_thread() is not threading.main_thread():
+                        update_ui_data(targets={user: {'status': 'Paused: Session re-login required'}})
+                        log_activity("Monitoring paused: Session re-login required via Web Dashboard", user=user)
+                        print(f"* Monitoring paused for {user}. Please refresh/import session via Web Dashboard.")
+                        log_activity(f"Account '{SESSION_USERNAME or '<anonymous>'}' is flagged by Instagram. You must log in and clear any warnings.", user=user)
+                        print(f"* Error: Account '{SESSION_USERNAME or '<anonymous>'}' is flagged by Instagram. You must log in and clear any warnings.")
+                        print_cur_ts("\nTimestamp:\t\t\t\t")
+                    else:
+                        update_ui_data(targets={user: {'status': 'Main Instagram account flagged for automation. Exiting script.'}})
+                        log_activity(f"Account '{SESSION_USERNAME or '<anonymous>'}' is flagged by Instagram for automation. You must log in and clear any warnings.", user=user)
+                        log_activity(f"Exiting script", user=user)
+                        print(f"* Error: Account {SESSION_USERNAME} is flagged by Instagram for automation. You must log in and clear any warnings. Exiting script.")
                         sys.exit(1)
 
                     # Wait for session refresh or stop event


### PR DESCRIPTION
This identifies the specific cases that indicate an account that has been flagged or shadowbanned. It can be detected at script start or an account can enter this state during runtime. If detected, it messages and exits if single-monitored or that account goes idle if multi-threaded.

These are examples of the error messages indicating a flagged account:
`* Error: ProfileNotExistsException: Profile XXX does not exist.`
`* Error: AbortDownloadException: Query to https://www.instagram.com/graphql/query responded with "400 Bad Request": {"message":"checkpoint_required","checkpoint_url":"https://www.instagram.com/challenge/?next=/graphql/query","lock":false,"flow_render_type":0,"status":"fail"}`