### PR TITLE
Fix privacy substitution issues

### DIFF
--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -3793,7 +3793,7 @@ def debug_print(message):
             print()
             _thread_local.in_partial_line = False
 
-        print(apply_privacy_substitutions(f"[DEBUG {timestamp}]{user_prefix} {message}"))
+        print(f"[DEBUG {timestamp}]{user_prefix} {message}")  # substitution applied in LOGGER.write
 
 
 # Initializes the CSV file

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -1362,8 +1362,12 @@ def create_web_dashboard_app():
                 data = apply_privacy_substitutions(data)  # substitute everything else
                 substituted_targets = {}
                 for username, t_data in raw_targets.items():
-                    substituted_t_data = apply_privacy_substitutions(t_data) if isinstance(t_data, dict) else t_data
-                    substituted_t_data['display_name'] = apply_privacy_substitutions(username)
+                    if isinstance(t_data, dict):
+                        substituted_t_data = apply_privacy_substitutions(t_data)
+                        substituted_t_data['display_name'] = apply_privacy_substitutions(username)
+                    else:
+                        # Non-dict target payload: pass through unchanged, can't attach display_name
+                        substituted_t_data = t_data
                     substituted_targets[username] = substituted_t_data
                 data['targets'] = substituted_targets
             else:
@@ -3757,7 +3761,9 @@ def apply_privacy_substitutions(content: TPrivacyContent) -> TPrivacyContent:
     """
     - Recurses into dict values and list items
     - For strings, performs search/replace using PRIVACY_SUBSTITIONS
-    - Preserves dictionary keys to keep API object identity stable
+    - Preserves dict keys so JSON and object keys stay stable for API
+      consumers. Callers that display a key (e.g. terminal target tables)
+      must substitute it explicitly at the point of display
     - Ignores invalid substitution entries to avoid runtime crashes
     - Non-string primitives are returned unchanged
     """
@@ -3783,10 +3789,7 @@ def apply_privacy_substitutions(content: TPrivacyContent) -> TPrivacyContent:
             content_str = content_str.replace(search, replace)
         return cast(TPrivacyContent, content_str)
     if isinstance(content, dict):
-            return cast(TPrivacyContent, {
-                apply_privacy_substitutions(k) if isinstance(k, str) else k: apply_privacy_substitutions(v)
-                for k, v in content.items()
-            })
+        return cast(TPrivacyContent, {k: apply_privacy_substitutions(v) for k, v in content.items()})
     if isinstance(content, list):
         return cast(TPrivacyContent, [apply_privacy_substitutions(item) for item in content])
     return content
@@ -5381,6 +5384,8 @@ def generate_dashboard_targets_table(target_data):
 
     now_ts = datetime.now().timestamp()
     for target, data in target_data.items():
+        # Substitute the displayed target name here. Dict keys stay real upstream so API consumers keep stable keys
+        display_target = apply_privacy_substitutions(target)
         status_val = data.get('status', 'Unknown')
         status_style = "green" if status_val == 'OK' else "yellow" if status_val in ('Checking', 'Starting', 'Loading Profile', 'Fetching Reels') else "blue"
 
@@ -5408,7 +5413,7 @@ def generate_dashboard_targets_table(target_data):
             next_chk = get_squeezed_date_from_ts(next_ts, show_seconds=DASHBOARD_SHOW_CHECK_SECONDS)
 
         table.add_row(
-            target,
+            display_target,
             visibility,
             str(data.get('followers') if data.get('followers') is not None else '-'),
             str(data.get('following') if data.get('following') is not None else '-'),

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -2515,7 +2515,6 @@ def update_ui_data(targets=None, config=None, check_count=None, last_check=None,
                             tgt_parts.append(f"session={s}")
                 parts.append(f"[{', '.join(tgt_parts)}]")
         if parts:
-            parts = apply_privacy_substitutions(parts)
             debug_print(f"UI Data Update: {', '.join(parts)}")
     if DASHBOARD_ENABLED or WEB_DASHBOARD_ENABLED:
         if DASHBOARD_ENABLED:

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -1356,7 +1356,18 @@ def create_web_dashboard_app():
                 # Keep output best-effort; don't break dashboard on edge cases
                 pass
 
-            data = apply_privacy_substitutions(data)
+            # Substitute values but preserve real username keys; add display_name for UI
+            if 'targets' in data:
+                raw_targets = data.pop('targets')  # remove before substituting data
+                data = apply_privacy_substitutions(data)  # substitute everything else
+                substituted_targets = {}
+                for username, t_data in raw_targets.items():
+                    substituted_t_data = apply_privacy_substitutions(t_data) if isinstance(t_data, dict) else t_data
+                    substituted_t_data['display_name'] = apply_privacy_substitutions(username)
+                    substituted_targets[username] = substituted_t_data
+                data['targets'] = substituted_targets
+            else:
+                data = apply_privacy_substitutions(data)
             return jsonify(data)  # type: ignore
 
     # Catch TemplateNotFound specifically to show friendly error
@@ -5450,7 +5461,7 @@ def generate_user_dashboard(target_data):
     if not RICH_AVAILABLE:
         return None
 
-    target_data = apply_privacy_substitutions(target_data)
+    display_target_data = apply_privacy_substitutions(target_data)
 
     # Type guard: Rich is available at this point
     assert Table is not None
@@ -5472,7 +5483,7 @@ def generate_user_dashboard(target_data):
     )
     header_panel = Panel(header_text, style="white on blue", box=box.SQUARE)
 
-    table = generate_dashboard_targets_table(target_data)
+    table = generate_dashboard_targets_table(display_target_data)
 
     # Activity Log Panel (Latest at bottom)
     activities = DASHBOARD_DATA.get('activities', [])
@@ -5614,7 +5625,7 @@ def generate_config_dashboard(target_data, config_data):
     if not RICH_AVAILABLE:
         return None
 
-    target_data = apply_privacy_substitutions(target_data)
+    display_target_data = apply_privacy_substitutions(target_data)
     config_data = apply_privacy_substitutions(config_data)
 
     # Type guard: Rich is available at this point
@@ -5634,7 +5645,7 @@ def generate_config_dashboard(target_data, config_data):
     header_panel = Panel(header_text, style="white on blue", box=box.SQUARE)
 
     # Main targets table - unified with user mode
-    targets_table = generate_dashboard_targets_table(target_data)
+    targets_table = generate_dashboard_targets_table(display_target_data)
 
     # Configuration tables (two columns for better space usage)
     config_table_left = Table(box=box.ROUNDED, show_header=False, header_style="bold magenta", border_style="magenta")

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -5506,11 +5506,12 @@ def generate_user_dashboard(target_data):
         return ts_val if isinstance(ts_val, (int, float)) else 0
 
     def append_update_entry(update, fallback_user):
-        user_label = update.get('user') or fallback_user or "Unknown"
+        # Substitute display-only fields (name, caption) but keep file paths and URLs real so they stay locatable/clickable
+        user_label = apply_privacy_substitutions(update.get('user') or fallback_user or "Unknown")
         last_fetched_text.append(f"User: {user_label}\n", style="bold green")
         last_fetched_text.append(f"Type: {update.get('type', 'Unknown')}\n", style="bold cyan")
         last_fetched_text.append(f"Date: {update.get('timestamp', '-')}\n", style="dim")
-        caption = update.get('caption', '')
+        caption = apply_privacy_substitutions(update.get('caption', ''))
         if caption:
             caption = caption.replace('\n', ' ')
             if len(caption) > 60:

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -1811,7 +1811,7 @@ def create_web_dashboard_app():
         global SESSION_USERNAME, SKIP_SESSION
 
         if flask_request.method == 'GET':  # type: ignore
-            return jsonify(get_web_dashboard_session_data())  # type: ignore
+            return jsonify(apply_privacy_substitutions(get_web_dashboard_session_data()))  # type: ignore
         elif flask_request.method == 'POST':  # type: ignore
             data = flask_request.get_json()  # type: ignore
             if not data:
@@ -3772,7 +3772,10 @@ def apply_privacy_substitutions(content: TPrivacyContent) -> TPrivacyContent:
             content_str = content_str.replace(search, replace)
         return cast(TPrivacyContent, content_str)
     if isinstance(content, dict):
-        return cast(TPrivacyContent, {k: apply_privacy_substitutions(v) for k, v in content.items()})
+            return cast(TPrivacyContent, {
+                apply_privacy_substitutions(k) if isinstance(k, str) else k: apply_privacy_substitutions(v)
+                for k, v in content.items()
+            })
     if isinstance(content, list):
         return cast(TPrivacyContent, [apply_privacy_substitutions(item) for item in content])
     return content

--- a/templates/index.html
+++ b/templates/index.html
@@ -2087,7 +2087,7 @@
                     <tr>
                         <td>
                             <div class="target-name">
-                                <div class="target-avatar">${name.charAt(0).toUpperCase()}</div>
+                                <div class="target-avatar">${displayName.charAt(0).toUpperCase()}</div>
                                 <div>
                                     <div><a href="https://instagram.com/${encodeURIComponent(name)}" target="_blank" style="color: inherit; text-decoration: none;">${escapeHtml(displayName)}</a></div>
                                     <div style="font-size: 12px; color: #666;">@${escapeHtml(displayName)}</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -2045,8 +2045,8 @@
             }
 
             const renderRow = ([name, data], isSimple = false, isTargetsList = false) => {
-				const displayName = data.display_name || name;
-				const statusVal = data.status || 'Idle';
+                const displayName = data.display_name || name;
+                const statusVal = data.status || 'Idle';
                 const statusClass = getStatusBadge(statusVal);
                 const isPrivate = data.is_private;
                 const visibility = isPrivate === true ? 'PRI' : (isPrivate === false ? 'PUB' : '-');

--- a/templates/index.html
+++ b/templates/index.html
@@ -2045,7 +2045,8 @@
             }
 
             const renderRow = ([name, data], isSimple = false, isTargetsList = false) => {
-                const statusVal = data.status || 'Idle';
+				const displayName = data.display_name || name;
+				const statusVal = data.status || 'Idle';
                 const statusClass = getStatusBadge(statusVal);
                 const isPrivate = data.is_private;
                 const visibility = isPrivate === true ? 'PRI' : (isPrivate === false ? 'PUB' : '-');
@@ -2062,8 +2063,8 @@
                         <tr>
                             <td>
                                 <div class="target-name">
-                                    <div class="target-avatar">${name.charAt(0).toUpperCase()}</div>
-                                    <span><a href="https://instagram.com/${encodeURIComponent(name)}" target="_blank" style="color: inherit; text-decoration: none;">${escapeHtml(name)}</a></span>
+                                    <div class="target-avatar">${displayName.charAt(0).toUpperCase()}</div>
+                                    <span><a href="https://instagram.com/${encodeURIComponent(name)}" target="_blank" style="color: inherit; text-decoration: none;">${escapeHtml(displayName)}</a></span>
                                 </div>
                             </td>
                             <td>${data.added || '-'}</td>
@@ -2088,8 +2089,8 @@
                             <div class="target-name">
                                 <div class="target-avatar">${name.charAt(0).toUpperCase()}</div>
                                 <div>
-                                    <div><a href="https://instagram.com/${encodeURIComponent(name)}" target="_blank" style="color: inherit; text-decoration: none;">${escapeHtml(name)}</a></div>
-                                    <div style="font-size: 12px; color: #666;">@${escapeHtml(name)}</div>
+                                    <div><a href="https://instagram.com/${encodeURIComponent(name)}" target="_blank" style="color: inherit; text-decoration: none;">${escapeHtml(displayName)}</a></div>
+                                    <div style="font-size: 12px; color: #666;">@${escapeHtml(displayName)}</div>
                                 </div>
                             </div>
                         </td>


### PR DESCRIPTION
This fixes 2 issues.

1. After refreshing the web dashboard and then clicking the sessions tab, the substitutions were not occurring for about 5-6 seconds, but then it would refresh and they were substituted.
2. The target names were not being substituted in the web and terminal dashboards. The issue is that the substitution routine for dicts was not substituting on keys.
