### PR TITLE
Improve get_ip_address via IP_ADDRESS_URL

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,7 +14,7 @@ Version **3.8** strengthens **Discord and ntfy webhook delivery**, adds safer **
 - **IMPROVE:** Added **native ntfy image attachments** with a 5 MiB limit and automatic text-only fallback when image preparation or upload fails
 - **IMPROVE:** Made the **status, follower and error webhook controls** enable webhook delivery for the current run
 - **IMPROVE:** Split the startup notification summary into compact **email and webhook rows** across concise, verbose and logged views
-- **IMPROVE:** Added ordered **proxy IP lookup fallback endpoints** with backward-compatible single-URL configuration, IPv4 and IPv6 validation plus documented privacy controls
+- **IMPROVE:** Added ordered **proxy IP lookup fallback endpoints** with backward-compatible single-URL configuration, IPv4 and IPv6 validation plus documented privacy controls (thanks [@tomballgithub](https://github.com/tomballgithub), from [#113](https://github.com/misiektoja/instagram_monitor/pull/113))
 
 **Bug fixes**:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,7 @@ This is a high-level summary of the most important changes.
 
 # Changes in 3.8 (TBD)
 
-Version **3.8** strengthens **Discord and ntfy webhook delivery**, adds safer **private URL setup** and brings better notification controls.
+Version **3.8** strengthens **Discord and ntfy webhook delivery**, adds safer **private URL setup**, improves **proxy IP detection** and brings better notification controls.
 
 **Features and improvements**:
 
@@ -14,6 +14,7 @@ Version **3.8** strengthens **Discord and ntfy webhook delivery**, adds safer **
 - **IMPROVE:** Added **native ntfy image attachments** with a 5 MiB limit and automatic text-only fallback when image preparation or upload fails
 - **IMPROVE:** Made the **status, follower and error webhook controls** enable webhook delivery for the current run
 - **IMPROVE:** Split the startup notification summary into compact **email and webhook rows** across concise, verbose and logged views
+- **IMPROVE:** Added ordered **proxy IP lookup fallback endpoints** with backward-compatible single-URL configuration, IPv4 and IPv6 validation plus documented privacy controls
 
 **Bug fixes**:
 
@@ -21,6 +22,7 @@ Version **3.8** strengthens **Discord and ntfy webhook delivery**, adds safer **
 - **BUGFIX:** Kept long ntfy messages below its 4 KB attachment boundary, added a visible truncation explanation and preserved complete UTF-8 characters
 - **BUGFIX:** Restored green `On` and red `Off` status cues in compact notification rows without coloring category text
 - **BUGFIX:** Made `SIGHUP` apply rotated proxy credentials to active Instaloader sessions and redetect Discord or ntfy when the private webhook destination changes
+- **BUGFIX:** Made proxy IP failover try every configured endpoint before the long retry delay, reject invalid successful responses without crashing and preserve custom endpoint lists in generated configuration
 
 # Changes in 3.7.1 (24 Jul 2026)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,22 @@ If the same setting appears in more than one place, the item later in this list 
 
 The `.env` and process environment layer applies only to `SESSION_PASSWORD`, `SMTP_PASSWORD`, `WEBHOOK_URL`, `PROXY_URL` and `NTFY_ACCESS_TOKEN`. For these keys, a value in the selected `.env` file replaces a value that was already exported in the shell. Use `--config-file PATH` and `--env-file PATH` if you do not want automatic file discovery.
 
+### Proxy IP Lookup Endpoints
+
+When proxy routing is enabled, Instagram Monitor checks the proxy exit address through `IP_ADDRESS_URL`. The setting accepts one complete HTTP or HTTPS URL or an ordered non-empty list:
+
+```ini
+IP_ADDRESS_URL = [
+    "https://checkip.amazonaws.com",
+    "https://api.ipify.org?format=json",
+    "https://api.my-ip.io/v2/ip.json",
+]
+```
+
+Each retry cycle tries every configured endpoint in order before the long retry delay. A response is accepted only when a recognized JSON field or plain-text body contains a valid IPv4 or IPv6 address. Empty lists, incomplete URLs and URLs with embedded credentials are rejected with an unavailable status instead of crashing monitoring.
+
+Each public lookup service can observe the proxy exit IP. Set one trusted endpoint or a self-hosted service if you do not want fallback requests sent to multiple providers. These lookup requests do not include Instagram session credentials.
+
 Save one or more monitoring targets through setup or set `TARGET_USERNAMES` yourself:
 
 ```ini

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -518,6 +518,7 @@ Additional options:
 
 - `PROXY_CERT_PATH` or `--proxy-cert` selects a local certificate used to verify the proxy connection
 - `PROXY_WEBHOOKS` or `--enable-proxy-webhooks` also sends webhook requests through the proxy. It is off by default because some proxies do not allow these requests
+- `IP_ADDRESS_URL` selects one trusted IP lookup URL or an ordered non-empty list of fallback URLs
 
 `PROXY_URL` may contain a username and password. The tool masks it in output. Store it through an [environment variable or `.env` file](configuration.md#storing-secrets).
 
@@ -526,7 +527,14 @@ PROXY_ENABLED = True
 PROXY_URL = "http://user:pass@host:port"
 PROXY_CERT_PATH = ""
 PROXY_WEBHOOKS = False
+IP_ADDRESS_URL = [
+    "https://checkip.amazonaws.com",
+    "https://api.ipify.org?format=json",
+    "https://api.my-ip.io/v2/ip.json",
+]
 ```
+
+The proxy IP check tries each endpoint in order without pausing between different providers. It waits for the long retry delay only after the complete list fails. Only valid IPv4 or IPv6 responses are displayed. See [Proxy IP Lookup Endpoints](configuration.md#proxy-ip-lookup-endpoints) for validation and privacy details.
 
 The Python `requests` library reads `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` from the process environment even when `PROXY_ENABLED` is `False`. Check and unset those variables if you need a direct connection.
 

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -365,15 +365,9 @@ CHECK_INTERNET_URL = 'https://www.instagram.com/'
 # Timeout used when checking initial internet connectivity in seconds
 CHECK_INTERNET_TIMEOUT = 5
 
-# URL or list of URLs used to determine IP address
-# If first URL doesn't provide a valid response, retries will iterate through the list
-IP_ADDRESS_URL = [
-    "https://checkip.amazonaws.com",
-    "https://api.ipify.org?format=json",
-    "https://api.my-ip.io/ip.json",
-    "https://ipinfo.io/json",
-    "https://httpbin.org/ip",
-]
+# Complete HTTP or HTTPS URL or ordered non-empty list of URLs used to determine the proxy IP address
+# Each retry cycle tries every URL before waiting for the long retry delay
+IP_ADDRESS_URL = ["https://checkip.amazonaws.com", "https://api.ipify.org?format=json", "https://api.my-ip.io/v2/ip.json", "https://ipinfo.io/json", "https://httpbin.org/ip"]
 
 # ----------------------------
 # Restricted Monitoring Hours
@@ -980,13 +974,7 @@ ADVANCED_FOLLOWEE_FETCH = False
 LIVENESS_CHECK_INTERVAL = 0
 CHECK_INTERNET_URL = ""
 CHECK_INTERNET_TIMEOUT = 0
-IP_ADDRESS_URL = [
-    "https://checkip.amazonaws.com",
-    "https://api.ipify.org?format=json",
-    "https://api.my-ip.io/ip.json",
-    "https://ipinfo.io/json",
-    "https://httpbin.org/ip",
-]
+IP_ADDRESS_URL = ["https://checkip.amazonaws.com", "https://api.ipify.org?format=json", "https://api.my-ip.io/v2/ip.json", "https://ipinfo.io/json", "https://httpbin.org/ip"]
 CHECK_POSTS_IN_HOURS_RANGE = False
 HOURS_VERBOSE = False
 MIN_H1 = 0
@@ -4852,47 +4840,99 @@ def interruptible_sleep(seconds, stop_event=None):
     return stop_event.wait(seconds)
 
 
-# Fetches the current outbound IP via IP_ADDRESS_URL, tolerating JSON and plain-text responses.
+# Returns a validated ordered list of configured IP lookup endpoints
+def normalize_ip_address_urls(value=None) -> list[str]:
+    configured = IP_ADDRESS_URL if value is None else value
+    if isinstance(configured, str):
+        candidates = [configured]
+    elif isinstance(configured, list):
+        candidates = configured
+    else:
+        raise ValueError("IP_ADDRESS_URL must be a complete HTTP or HTTPS URL or a list of URLs")
+    if not candidates:
+        raise ValueError("IP_ADDRESS_URL must contain at least one URL")
+
+    urls = []
+    for index, candidate in enumerate(candidates, start=1):
+        if not isinstance(candidate, str) or not candidate.strip():
+            raise ValueError(f"IP_ADDRESS_URL entry {index} must be a non-empty URL string")
+        url = candidate.strip()
+        parsed = urlsplit(url)
+        if parsed.scheme.lower() not in ("http", "https") or not parsed.hostname:
+            raise ValueError(f"IP_ADDRESS_URL entry {index} must be a complete HTTP or HTTPS URL")
+        if parsed.username or parsed.password:
+            raise ValueError(f"IP_ADDRESS_URL entry {index} must not contain embedded credentials")
+        urls.append(url)
+    return urls
+
+
+# Extracts and validates an IPv4 or IPv6 address from one lookup response
+def _extract_ip_address_response(ip_response) -> str:
+    try:
+        data = ip_response.json()
+    except ValueError:
+        data = None
+
+    candidates = []
+    if isinstance(data, dict):
+        for key in ("origin", "ip", "ip_addr", "address", "query"):
+            value = data.get(key)
+            if isinstance(value, str) and value.strip():
+                candidates.append(value)
+    elif isinstance(data, str) and data.strip():
+        candidates.append(data)
+    else:
+        text = (ip_response.text or "").strip()
+        if text:
+            candidates.append(text.splitlines()[0])
+
+    for candidate in candidates:
+        normalized = candidate.strip().split(",")[0].strip()
+        try:
+            return str(ipaddress.ip_address(normalized))
+        except ValueError:
+            continue
+    raise ValueError("response did not contain a valid IPv4 or IPv6 address")
+
+
+# Fetches the current outbound IP by trying every configured endpoint before each long retry
 def get_ip_address(max_retries=3, timeout=10, retry_delay=5, long_retry=120, long_retry_attempts=3, stop_event=None):
-    urls = IP_ADDRESS_URL if isinstance(IP_ADDRESS_URL, list) else [IP_ADDRESS_URL]
-    if isinstance(urls, list) and len(urls) > long_retry_attempts:
-        long_retry_attemps = len(urls)
+    try:
+        urls = normalize_ip_address_urls()
+        if not isinstance(max_retries, int) or max_retries < 1:
+            raise ValueError("max_retries must be at least 1")
+        if not isinstance(long_retry_attempts, int) or long_retry_attempts < 1:
+            raise ValueError("long_retry_attempts must be at least 1")
+    except ValueError as exc:
+        debug_print(f"get_ip_address configuration error: {exc}")
+        return f"(unavailable: {format_error_message(exc)})"
 
     last_err = None
-    site_index = 0
+    attempts_per_cycle = max(max_retries, len(urls))
     for long_attempt in range(1, long_retry_attempts + 1):
-        for attempt in range(1, max_retries + 1):
+        for attempt_index in range(attempts_per_cycle):
             if stop_event is not None and stop_event.is_set():
                 return f"(unavailable: {format_error_message(last_err) if last_err else 'stopped'})"
-            url = urls[site_index % len(urls)]
+            url = urls[attempt_index % len(urls)]
             try:
                 ip_response = req.get(url, timeout=timeout, verify=get_proxies_ssl(), proxies=get_proxies())
                 ip_response.raise_for_status()
-                try:
-                    data = ip_response.json()
-                except ValueError:
-                    data = None
-                if isinstance(data, dict):
-                    for key in ('origin', 'ip', 'ip_addr', 'address', 'query'):
-                        val = data.get(key)
-                        if isinstance(val, str) and val.strip():
-                            return val.strip().split(',')[0].strip()
-                text = (ip_response.text or "").strip()
-                if text:
-                    return text.splitlines()[0].strip()
-                raise ValueError(f"empty response body from {url}")
-            except Exception as e:
-                last_err = e
-                site_index += 1  # rotate on any failure
-                debug_print(f"error during get_ip_address() from {url}")
-                if attempt < max_retries and interruptible_sleep(retry_delay, stop_event):
-                    return f"(unavailable: {format_error_message(last_err)})"
+                return _extract_ip_address_response(ip_response)
+            except Exception as exc:
+                last_err = exc
+                debug_print(f"get_ip_address endpoint failed at {mask_url_credentials(url)}: {format_error_message(exc)}")
+
+            next_attempt = attempt_index + 1
+            completed_endpoint_pass = next_attempt % len(urls) == 0
+            if next_attempt < attempts_per_cycle and completed_endpoint_pass and interruptible_sleep(retry_delay, stop_event):
+                return f"(unavailable: {format_error_message(last_err)})"
+
         if long_attempt < long_retry_attempts:
-            debug_print(f"get_ip_address: all {max_retries} attempts failed in loop {long_attempt}/{long_retry_attempts}, retrying in {long_retry} seconds: {last_err}")
+            debug_print(f"get_ip_address: all {attempts_per_cycle} endpoint attempts failed in cycle {long_attempt}/{long_retry_attempts}, retrying in {long_retry} seconds: {last_err}")
             if interruptible_sleep(long_retry, stop_event):
                 return f"(unavailable: {format_error_message(last_err) if last_err else 'stopped'})"
         else:
-            debug_print(f"get_ip_address failed after {long_retry_attempts} loops of {max_retries} attempts: {last_err}")
+            debug_print(f"get_ip_address failed after {long_retry_attempts} cycles of {attempts_per_cycle} endpoint attempts: {last_err}")
     return f"(unavailable: {format_error_message(last_err) if last_err else 'unknown error'})"
 
 

--- a/instagram_monitor.py
+++ b/instagram_monitor.py
@@ -285,8 +285,15 @@ CHECK_INTERNET_URL = 'https://www.instagram.com/'
 # Timeout used when checking initial internet connectivity; in seconds
 CHECK_INTERNET_TIMEOUT = 5
 
-# URL used to determine IP address
-IP_ADDRESS_URL = 'https://httpbin.org/ip'
+# URL or list of URLs used to determine IP address
+# If first URL doesn't provide a valid response, retries will iterate through the list
+IP_ADDRESS_URL = [
+    "https://checkip.amazonaws.com",
+    "https://api.ipify.org?format=json",
+    "https://api.my-ip.io/ip.json",
+    "https://ipinfo.io/json",
+    "https://httpbin.org/ip",
+]
 
 # Limit fetching updates to specific hours of the day?
 # If True, the tool will only fetch updates within the defined hour ranges below
@@ -846,7 +853,13 @@ ADVANCED_FOLLOWEE_FETCH = False
 LIVENESS_CHECK_INTERVAL = 0
 CHECK_INTERNET_URL = ""
 CHECK_INTERNET_TIMEOUT = 0
-IP_ADDRESS_URL = ""
+IP_ADDRESS_URL = [
+    "https://checkip.amazonaws.com",
+    "https://api.ipify.org?format=json",
+    "https://api.my-ip.io/ip.json",
+    "https://ipinfo.io/json",
+    "https://httpbin.org/ip",
+]
 CHECK_POSTS_IN_HOURS_RANGE = False
 HOURS_VERBOSE = False
 MIN_H1 = 0
@@ -4512,15 +4525,21 @@ def interruptible_sleep(seconds, stop_event=None):
     return stop_event.wait(seconds)
 
 
-# Fetches the current outbound IP via IP_ADDRESS_URL, tolerating JSON and plain-text responses
-def get_ip_address(max_retries=5, timeout=10, retry_delay=5, long_retry=120, long_retry_attempts=3, stop_event=None):
+# Fetches the current outbound IP via IP_ADDRESS_URL, tolerating JSON and plain-text responses.
+def get_ip_address(max_retries=3, timeout=10, retry_delay=5, long_retry=120, long_retry_attempts=3, stop_event=None):
+    urls = IP_ADDRESS_URL if isinstance(IP_ADDRESS_URL, list) else [IP_ADDRESS_URL]
+    if isinstance(urls, list) and len(urls) > long_retry_attempts:
+        long_retry_attemps = len(urls)
+
     last_err = None
+    site_index = 0
     for long_attempt in range(1, long_retry_attempts + 1):
         for attempt in range(1, max_retries + 1):
             if stop_event is not None and stop_event.is_set():
                 return f"(unavailable: {format_error_message(last_err) if last_err else 'stopped'})"
+            url = urls[site_index % len(urls)]
             try:
-                ip_response = req.get(IP_ADDRESS_URL, timeout=timeout, verify=get_proxies_ssl(), proxies=get_proxies())
+                ip_response = req.get(url, timeout=timeout, verify=get_proxies_ssl(), proxies=get_proxies())
                 ip_response.raise_for_status()
                 try:
                     data = ip_response.json()
@@ -4534,9 +4553,11 @@ def get_ip_address(max_retries=5, timeout=10, retry_delay=5, long_retry=120, lon
                 text = (ip_response.text or "").strip()
                 if text:
                     return text.splitlines()[0].strip()
-                raise ValueError(f"empty response body from {IP_ADDRESS_URL}")
+                raise ValueError(f"empty response body from {url}")
             except Exception as e:
                 last_err = e
+                site_index += 1  # rotate on any failure
+                debug_print(f"error during get_ip_address() from {url}")
                 if attempt < max_retries and interruptible_sleep(retry_delay, stop_event):
                     return f"(unavailable: {format_error_message(last_err)})"
         if long_attempt < long_retry_attempts:

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,6 +26,7 @@ installed copy of the package.
 | File | Area under test |
 | --- | --- |
 | `test_config_generation.py` | Config inline-comment splitting, value formatting, `generate_config_with_current_values` round-trip |
+| `test_proxy_ip.py` | Proxy IP endpoint validation, IPv4/IPv6 parsing, ordered failover and retry timing |
 | `test_time_and_dates.py` | `display_time`, `calculate_timespan`, hour formatting, timezone conversions |
 | `test_privacy.py` | `apply_privacy_substitutions` (string/dict/list recursion, invalid entries) |
 | `test_notifications.py` | Webhook URL validation, Discord markdown escaping, credential masking, payload templating |

--- a/tests/test_config_generation.py
+++ b/tests/test_config_generation.py
@@ -84,6 +84,17 @@ class TestGenerateConfigWithCurrentValues:
         assert "SESSION_USERNAME" in rendered
         assert rendered.count("#") > 10
 
+    # Generated config preserves a customized ordered IP lookup endpoint list
+    def test_ip_address_urls_round_trip_from_runtime_values(self, im_module, monkeypatch):
+        custom_urls = ["https://primary.example.test/ip", "https://backup.example.test/ip"]
+        monkeypatch.setattr(im_module, "IP_ADDRESS_URL", custom_urls)
+
+        rendered = im_module.generate_config_with_current_values()
+        namespace: dict = {}
+        exec(rendered, namespace)
+
+        assert namespace["IP_ADDRESS_URL"] == custom_urls
+
     # Generated webhook defaults document private entry and suppress Discord mentions
     def test_webhook_defaults_match_safe_user_experience(self, im_module):
         rendered = im_module.generate_config_with_current_values()

--- a/tests/test_proxy_ip.py
+++ b/tests/test_proxy_ip.py
@@ -1,0 +1,166 @@
+"""Tests for proxy IP endpoint validation and failover behavior."""
+
+import threading
+from unittest.mock import Mock, call
+
+
+# Builds one fake HTTP response with configurable JSON and plain-text content
+def make_ip_response(payload=None, text="", json_error=False):
+    response = Mock()
+    response.text = text
+    response.raise_for_status.return_value = None
+    if json_error:
+        response.json.side_effect = ValueError("not JSON")
+    else:
+        response.json.return_value = payload
+    return response
+
+
+class TestIpAddressUrlValidation:
+    # Accepts a single URL or ordered list while trimming surrounding whitespace
+    def test_normalizes_supported_url_configuration(self, im_module):
+        assert im_module.normalize_ip_address_urls(" https://example.test/ip ") == ["https://example.test/ip"]
+        assert im_module.normalize_ip_address_urls(["https://one.test/ip", "http://two.test/ip"]) == ["https://one.test/ip", "http://two.test/ip"]
+
+    # Rejects empty malformed and credential-bearing endpoint configurations
+    def test_rejects_unsafe_or_unusable_url_configuration(self, im_module):
+        invalid_values = [[], (), [""], ["example.test/ip"], ["ftp://example.test/ip"], ["https://user:secret@example.test/ip"]]
+        for value in invalid_values:
+            try:
+                im_module.normalize_ip_address_urls(value)
+            except ValueError:
+                continue
+            raise AssertionError(f"Expected invalid IP_ADDRESS_URL value to fail: {value!r}")
+
+    # Keeps every built-in endpoint valid and uses the documented MyIP API path
+    def test_default_endpoints_are_valid_and_current(self, im_module):
+        urls = im_module.normalize_ip_address_urls()
+        assert "https://api.my-ip.io/v2/ip.json" in urls
+        assert all(url.startswith("https://") for url in urls)
+
+
+class TestIpAddressResponseParsing:
+    # Accepts documented JSON and plain-text IPv4 or IPv6 response formats
+    def test_extracts_valid_ipv4_and_ipv6_responses(self, im_module):
+        responses = [
+            (make_ip_response({"ip": "203.0.113.7"}), "203.0.113.7"),
+            (make_ip_response({"origin": "203.0.113.8, 198.51.100.2"}), "203.0.113.8"),
+            (make_ip_response("2001:db8::1"), "2001:db8::1"),
+            (make_ip_response(text="2001:db8::2\n", json_error=True), "2001:db8::2"),
+        ]
+        for response, expected in responses:
+            assert im_module._extract_ip_address_response(response) == expected
+
+    # Rejects successful HTTP responses that do not contain an IP address
+    def test_rejects_non_ip_response_bodies(self, im_module):
+        responses = [
+            make_ip_response({"ip": "not-an-ip"}),
+            make_ip_response({"status": "rate limited"}),
+            make_ip_response(text="<html>proxy login</html>", json_error=True),
+            make_ip_response(text="", json_error=True),
+        ]
+        for response in responses:
+            try:
+                im_module._extract_ip_address_response(response)
+            except ValueError:
+                continue
+            raise AssertionError("Expected response without an IP address to fail")
+
+
+class TestGetIpAddressFailover:
+    # Reaches every configured endpoint without sleeping between distinct providers
+    def test_tries_complete_endpoint_list_before_waiting(self, im_module, monkeypatch):
+        urls = [f"https://provider-{index}.test/ip" for index in range(5)]
+        monkeypatch.setattr(im_module, "IP_ADDRESS_URL", urls)
+        success = make_ip_response({"ip": "203.0.113.9"})
+        request_get = Mock(side_effect=[OSError("down 0"), OSError("down 1"), OSError("down 2"), OSError("down 3"), success])
+        sleep = Mock(return_value=False)
+        monkeypatch.setattr(im_module.req, "get", request_get)
+        monkeypatch.setattr(im_module, "interruptible_sleep", sleep)
+
+        result = im_module.get_ip_address(max_retries=3, long_retry_attempts=1)
+
+        assert result == "203.0.113.9"
+        assert [item.args[0] for item in request_get.call_args_list] == urls
+        sleep.assert_not_called()
+
+    # Tries every entry even when the configured list is longer than max_retries
+    def test_long_endpoint_list_is_not_truncated(self, im_module, monkeypatch):
+        urls = [f"https://provider-{index}.test/ip" for index in range(10)]
+        monkeypatch.setattr(im_module, "IP_ADDRESS_URL", urls)
+        request_get = Mock(side_effect=OSError("all unavailable"))
+        sleep = Mock(return_value=False)
+        monkeypatch.setattr(im_module.req, "get", request_get)
+        monkeypatch.setattr(im_module, "interruptible_sleep", sleep)
+
+        result = im_module.get_ip_address(max_retries=3, long_retry_attempts=1)
+
+        assert result.startswith("(unavailable:")
+        assert [item.args[0] for item in request_get.call_args_list] == urls
+        sleep.assert_not_called()
+
+    # Retries a single legacy URL with the short delay between attempts
+    def test_single_url_keeps_retry_behavior(self, im_module, monkeypatch):
+        monkeypatch.setattr(im_module, "IP_ADDRESS_URL", "https://provider.test/ip")
+        success = make_ip_response({"ip": "203.0.113.10"})
+        request_get = Mock(side_effect=[OSError("down 1"), OSError("down 2"), success])
+        sleep = Mock(return_value=False)
+        monkeypatch.setattr(im_module.req, "get", request_get)
+        monkeypatch.setattr(im_module, "interruptible_sleep", sleep)
+
+        result = im_module.get_ip_address(max_retries=3, retry_delay=7, long_retry_attempts=1)
+
+        assert result == "203.0.113.10"
+        assert request_get.call_count == 3
+        assert sleep.call_args_list == [call(7, None), call(7, None)]
+
+    # Applies the long delay only after every endpoint in a cycle fails
+    def test_long_retry_waits_after_complete_endpoint_cycle(self, im_module, monkeypatch):
+        urls = ["https://one.test/ip", "https://two.test/ip"]
+        monkeypatch.setattr(im_module, "IP_ADDRESS_URL", urls)
+        request_get = Mock(side_effect=OSError("unavailable"))
+        sleep = Mock(return_value=False)
+        monkeypatch.setattr(im_module.req, "get", request_get)
+        monkeypatch.setattr(im_module, "interruptible_sleep", sleep)
+
+        result = im_module.get_ip_address(max_retries=1, long_retry=11, long_retry_attempts=2)
+
+        assert result.startswith("(unavailable:")
+        assert [item.args[0] for item in request_get.call_args_list] == urls + urls
+        assert sleep.call_args_list == [call(11, None)]
+
+    # Continues failover when an endpoint returns a successful non-IP response
+    def test_invalid_success_response_rotates_to_next_endpoint(self, im_module, monkeypatch):
+        urls = ["https://bad.test/ip", "https://good.test/ip"]
+        monkeypatch.setattr(im_module, "IP_ADDRESS_URL", urls)
+        request_get = Mock(side_effect=[make_ip_response(text="<html>blocked</html>", json_error=True), make_ip_response({"ip": "203.0.113.11"})])
+        monkeypatch.setattr(im_module.req, "get", request_get)
+
+        result = im_module.get_ip_address(max_retries=1, long_retry_attempts=1)
+
+        assert result == "203.0.113.11"
+        assert [item.args[0] for item in request_get.call_args_list] == urls
+
+    # Returns a bounded unavailable result for an empty endpoint list
+    def test_empty_endpoint_list_does_not_crash(self, im_module, monkeypatch):
+        monkeypatch.setattr(im_module, "IP_ADDRESS_URL", [])
+        request_get = Mock()
+        monkeypatch.setattr(im_module.req, "get", request_get)
+
+        result = im_module.get_ip_address()
+
+        assert result == "(unavailable: ValueError: IP_ADDRESS_URL must contain at least one URL)"
+        request_get.assert_not_called()
+
+    # Stops before making a request when the caller event is already set
+    def test_pre_set_stop_event_skips_requests(self, im_module, monkeypatch):
+        monkeypatch.setattr(im_module, "IP_ADDRESS_URL", ["https://provider.test/ip"])
+        request_get = Mock()
+        monkeypatch.setattr(im_module.req, "get", request_get)
+        stop_event = threading.Event()
+        stop_event.set()
+
+        result = im_module.get_ip_address(stop_event=stop_event)
+
+        assert result == "(unavailable: stopped)"
+        request_get.assert_not_called()


### PR DESCRIPTION
Add support for IP_ADDRESS_URL to be a list of sites, with multiple sites, checked rather than failing with a single URL in existing code. This is used only when PROXY_ENABLED

The current default site, https://httpbin.org/ip, is not consistently reliable.